### PR TITLE
chore: update relevance scoring

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -99,19 +99,21 @@ export class ContentEvaluatorModule implements Module {
 
     for (let i = 0; i < commentsWithScore.length; i++) {
       const currentComment = commentsWithScore[i];
-      let currentRelevance = 1; // For comments not in fixed relevance types and missed by OpenAI evaluation
+      let currentRelevance: number | string = '-'; // Default to '-' for skipped or unevaluated comments
 
       if (this._fixedRelevances[currentComment.type]) {
         currentRelevance = this._fixedRelevances[currentComment.type];
       } else if (!isNaN(relevancesByAI[currentComment.id])) {
         currentRelevance = relevancesByAI[currentComment.id];
+      } else  {
+        currentRelevance = '-';
       }
 
       const currentReward = new Decimal(currentComment.score?.reward || 0);
       currentComment.score = {
         ...(currentComment.score || {}),
         relevance: new Decimal(currentRelevance).toNumber(),
-        reward: currentReward.mul(currentRelevance).toNumber(),
+        reward: currentRelevance === '-' ? '-' : currentReward.mul(currentRelevance).toNumber(),
       };
     }
 

--- a/src/parser/processor.ts
+++ b/src/parser/processor.ts
@@ -99,7 +99,7 @@ export interface GithubCommentScore {
       content: Record<string, { symbols: { [p: string]: { count: number; multiplier: number } }; score: number }>;
       multiplier: number;
     };
-    relevance?: number;
+    relevance?: number | string;
     clarity?: number;
     reward: number;
   };


### PR DESCRIPTION
in content evaluator to distinguish skipped evaluations

- Modify relevance scoring to use - for skipped evaluations or fixed relevance multipliers.
- Adjust reward calculation to handle - relevance scores appropriately.
- Ensure type safety by allowing relevance to be either a number or string (-).
- Update comments for clarity on the new relevance scoring system.

Resolves #113 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
