### PR TITLE
fix: format decimal precision problem

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -127,7 +127,7 @@ export class ContentEvaluatorModule implements Module {
       currentComment.score = {
         ...(currentComment.score || { multiplier: 0 }),
         relevance: new Decimal(currentRelevance).toNumber(),
-        reward: currentReward.toNumber(),
+        reward: new Decimal(currentReward).mul(100).round().div(100).toNumber(),
       };
     }
 

--- a/src/parser/processor.ts
+++ b/src/parser/processor.ts
@@ -66,7 +66,7 @@ export class Processor {
       }
     }
 
-    return totalReward.toNumber();
+    return new Decimal(totalReward).mul(100).round().div(100).toNumber();
   }
 }
 

--- a/src/parser/user-extractor-module.ts
+++ b/src/parser/user-extractor-module.ts
@@ -52,7 +52,12 @@ export class UserExtractorModule implements Module {
     data.self?.assignees?.forEach((assignee) => {
       const task = data.self
         ? {
-            reward: new Decimal(this._extractTaskPrice(data.self)).mul(this._getTaskMultiplier(data.self)).toNumber(),
+            reward: new Decimal(this._extractTaskPrice(data.self))
+              .mul(this._getTaskMultiplier(data.self))
+              .mul(100)
+              .round()
+              .div(100)
+              .toNumber(),
             multiplier: this._getTaskMultiplier(data.self).toNumber(),
           }
         : undefined;


### PR DESCRIPTION
Resolves #77 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Offering a solution to the precision problem @0x4007 @gentlementlegen 

By scaling, flooring, and then displaying, you retain the intended precision without triggering floating-point issues