### PR TITLE
fix: priority default parsing

### DIFF
--- a/src/parser/formatting-evaluator-module.ts
+++ b/src/parser/formatting-evaluator-module.ts
@@ -175,7 +175,8 @@ export class FormattingEvaluatorModule extends BaseModule {
   }
 
   _parsePriorityLabel(labels: GitHubIssue["labels"] | undefined): number {
-    let taskPriorityEstimate = 0;
+    // Has to default to 1 in case there is no priority label
+    let taskPriorityEstimate = 1;
     if (!labels) return 1;
     for (const label of labels) {
       let priorityLabel = "";

--- a/tests/priority.test.ts
+++ b/tests/priority.test.ts
@@ -1,0 +1,31 @@
+import { ContextPlugin } from "../src/types/plugin-input";
+import { FormattingEvaluatorModule } from "../src/parser/formatting-evaluator-module";
+import { GitHubIssue } from "../src/github-types";
+import { describe, expect, it, jest } from "@jest/globals";
+
+describe("FormattingEvaluatorModule", () => {
+  const context = {
+    config: {
+      incentives: {
+        formattingEvaluator: null,
+      },
+    },
+    logger: {
+      error: jest.fn(),
+    },
+  } as unknown as ContextPlugin;
+
+  const module = new FormattingEvaluatorModule(context);
+
+  it("should default to priority 1 when no priority label is present", () => {
+    const labels: GitHubIssue["labels"] = [];
+    const priority = module["_parsePriorityLabel"](labels);
+    expect(priority).toBe(1);
+  });
+
+  it('should return priority 3 when "Priority: 3" label is present', () => {
+    const labels = ["Priority: 3"];
+    const priority = module["_parsePriorityLabel"](labels);
+    expect(priority).toBe(3);
+  });
+});


### PR DESCRIPTION
Defaulted priority multiplier to 1 if there is no tag, added related tests.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
