### PR TITLE
fix: user permission level is also retrieved from the repository itself

### DIFF
--- a/src/helpers/permissions.ts
+++ b/src/helpers/permissions.ts
@@ -1,0 +1,44 @@
+import { ContextPlugin } from "../types/plugin-input";
+
+export const ADMIN_ROLES = ["admin", "owner", "billing_manager"];
+export const COLLABORATOR_ROLES = ["write", "member", "collaborator"];
+
+function isAdminRole(role: string) {
+  return ADMIN_ROLES.includes(role.toLowerCase());
+}
+
+function isCollaboratorRole(role: string) {
+  return COLLABORATOR_ROLES.includes(role.toLowerCase());
+}
+
+export async function isUserAllowedToGeneratePermits(context: ContextPlugin) {
+  const { octokit, payload } = context;
+  const username = payload.sender.login;
+  try {
+    await octokit.rest.orgs.getMembershipForUser({
+      org: payload.repository.owner.login,
+      username,
+    });
+    return true;
+  } catch (e) {
+    context.logger.debug(`${username} is not a member of ${context.payload.repository.owner.login}`, { e });
+  }
+
+  // If we failed to get organization membership, narrow down to repo role
+  const permissionLevel = await octokit.rest.repos.getCollaboratorPermissionLevel({
+    username,
+    owner: context.payload.repository.owner.login,
+    repo: context.payload.repository.name,
+  });
+  const role = permissionLevel.data.role_name?.toLowerCase();
+  context.logger.debug(`Retrieved collaborator permission level for ${username}.`, {
+    username,
+    owner: context.payload.repository.owner.login,
+    repo: context.payload.repository.name,
+    isAdmin: permissionLevel.data.user?.permissions?.admin,
+    role,
+    data: permissionLevel.data,
+  });
+
+  return isAdminRole(role) || isCollaboratorRole(role);
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -7,21 +7,7 @@ import { Processor } from "./parser/processor";
 import { parseGitHubUrl } from "./start";
 import { ContextPlugin } from "./types/plugin-input";
 import { Result } from "./types/results";
-
-async function isUserAllowedToGeneratePermits(context: ContextPlugin) {
-  const { octokit, payload } = context;
-  const username = payload.sender.login;
-  try {
-    await octokit.rest.orgs.getMembershipForUser({
-      org: payload.repository.owner.login,
-      username,
-    });
-    return true;
-  } catch (e) {
-    context.logger.debug(`${username} is not a member of ${context.payload.repository.owner.login}`, { e });
-    return false;
-  }
-}
+import { isUserAllowedToGeneratePermits } from "./helpers/permissions";
 
 export async function run(context: ContextPlugin) {
   const { eventName, payload, logger, config } = context;

--- a/tests/__mocks__/handlers.ts
+++ b/tests/__mocks__/handlers.ts
@@ -212,4 +212,9 @@ export const handlers = [
   http.post("https://api.github.com/repos/:owner/:repo/issues/:id/comments", () => {
     return HttpResponse.json({});
   }),
+  http.get("https://api.github.com/repos/:owner/:repo/collaborators/:user/permission", () => {
+    return HttpResponse.json({
+        role_name: "admin",
+    });
+  }),
 ];

--- a/tests/pre-check.test.ts
+++ b/tests/pre-check.test.ts
@@ -8,6 +8,7 @@ import dbSeed from "./__mocks__/db-seed.json";
 import { server } from "./__mocks__/node";
 import cfg from "./__mocks__/results/valid-configuration.json";
 import { customOctokit as Octokit } from "@ubiquity-os/plugin-sdk/octokit";
+import { isUserAllowedToGeneratePermits } from "../src/helpers/permissions";
 
 const issueUrl = "https://github.com/ubiquity/work.ubq.fi/issues/69";
 
@@ -144,5 +145,50 @@ describe("Pre-check tests", () => {
     } as unknown as ContextPlugin);
 
     expect(result).toEqual("You are not allowed to generate permits.");
+  });
+
+  it("Should deny a user to generate permits if non-admin and allow admins", async () => {
+    const getMembershipForUser = jest.fn(() => ({}));
+    const getCollaboratorPermissionLevel = jest.fn(() => ({
+      data: {
+        role_name: "read",
+      },
+    }));
+    const ctx = {
+      payload: {
+        sender: {
+          login: "ubiquity-os",
+        },
+        repository: {
+          owner: {
+            login: "ubiquity-os-marketplace",
+          },
+        },
+      },
+      logger: new Logs("debug"),
+      octokit: {
+        rest: {
+          orgs: {
+            getMembershipForUser,
+          },
+          repos: {
+            getCollaboratorPermissionLevel,
+          },
+        },
+      },
+    } as unknown as ContextPlugin;
+
+    expect(await isUserAllowedToGeneratePermits(ctx)).toEqual(true);
+    getMembershipForUser.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    expect(await isUserAllowedToGeneratePermits(ctx)).toEqual(false);
+    getMembershipForUser.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    getCollaboratorPermissionLevel.mockImplementationOnce(() => {
+      return { data: { role_name: "write" } };
+    });
+    expect(await isUserAllowedToGeneratePermits(ctx)).toEqual(true);
   });
 });

--- a/tests/pre-check.test.ts
+++ b/tests/pre-check.test.ts
@@ -117,7 +117,18 @@ describe("Pre-check tests", () => {
       collectLinkedMergedPulls: jest.fn(() => []),
     }));
     const patchMock = jest.fn(() => HttpResponse.json({}));
-    server.use(http.patch("https://api.github.com/repos/ubiquity/work.ubq.fi/issues/69", patchMock, { once: true }));
+    server.use(
+      http.patch("https://api.github.com/repos/ubiquity/work.ubq.fi/issues/69", patchMock, { once: true }),
+      http.get(
+        "https://api.github.com/repos/:owner/:repo/collaborators/:user/permission",
+        () => {
+          return HttpResponse.json({
+            role_name: "read",
+          });
+        },
+        { once: true }
+      )
+    );
     const { run } = await import("../src/run");
 
     const result = await run({


### PR DESCRIPTION
Resolves #233
QA: https://github.com/Meniole/text-conversation-rewards/issues/47#issuecomment-2585589224 (user has write access only to the repository and is not part of the organization)
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
