### PR TITLE
Ignore PRs from users that are not assignees

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ export default tsEslint.config({
     "@typescript-eslint": tsEslint.plugin,
     "check-file": checkFile,
   },
-  ignores: [".github/knip.ts", "dist/", "tests/__mocks__/**", "coverage/**", "dist/**"],
+  ignores: [".github/knip.ts", "dist/", "tests/__mocks__/**", "coverage/**", "dist/**", "src/web/dist/**"],
   extends: [eslint.configs.recommended, ...tsEslint.configs.recommended, sonarjs.configs.recommended],
   languageOptions: {
     parser: tsEslint.parser,

--- a/src/data-collection/collect-linked-pulls.ts
+++ b/src/data-collection/collect-linked-pulls.ts
@@ -30,7 +30,5 @@ export async function collectLinkedMergedPulls(context: ContextPlugin, issue: Is
     issue_number,
   });
 
-  return result.repository.issue.closedByPullRequestsReferences.edges
-    .map((edge) => edge.node)
-    .filter((pull) => pull.state === "MERGED");
+  return result.repository.issue.closedByPullRequestsReferences.edges.map((edge) => edge.node);
 }

--- a/src/helpers/excluded-files.ts
+++ b/src/helpers/excluded-files.ts
@@ -65,7 +65,7 @@ async function getFileContent(
     return null;
   } catch (err) {
     if (err instanceof Error && "status" in err && err.status === 404) {
-      context.logger.error(
+      context.logger.info(
         `.gitattributes was not found for ${context.payload.repository.owner.login}/${context.payload.repository.name}`
       );
       return null;

--- a/src/helpers/github.ts
+++ b/src/helpers/github.ts
@@ -5,16 +5,15 @@ export function getGithubWorkflowRunUrl() {
   return `${github.context.payload.repository?.html_url}/actions/runs/${github.context.runId}`;
 }
 
-export function parsePriorityLabel(labels: GitHubIssue["labels"] | undefined) {
+export function parsePriorityLabel(labels?: GitHubIssue["labels"]) {
   if (!labels) return 1;
 
   for (const label of labels) {
-    const priorityLabel = typeof label === "string" ? label : (label.name ?? "");
-    const matched = priorityLabel.match(/^Priority:\s*(\d+)/i);
+    const priorityLabel = typeof label === "string" ? label : label.name;
+    const matched = priorityLabel?.match(/^Priority:\s*(\d+)/);
 
-    if (matched) {
-      const urgency = Number(matched[1]);
-      if (urgency) return urgency;
+    if (matched && Number.isFinite(Number(matched[1]))) {
+      return Number(matched[1]);
     }
   }
 

--- a/src/issue-activity.ts
+++ b/src/issue-activity.ts
@@ -53,8 +53,12 @@ export class IssueActivity {
 
   private async _getLinkedReviews(): Promise<Review[]> {
     this._context.logger.debug("Trying to fetch linked pull-requests for", this._issueParams);
-    const pulls = await collectLinkedMergedPulls(this._context, this._issueParams);
-    this._context.logger.debug(`Collected linked pull-requests ${pulls.map((v) => v.number)}`);
+    const pulls = (await collectLinkedMergedPulls(this._context, this._issueParams)).filter(
+      (pullRequest) =>
+        this._context.payload.issue.assignees.map((assignee) => assignee?.login).includes(pullRequest.author.login) &&
+        pullRequest.state === "MERGED"
+    );
+    this._context.logger.debug(`Collected linked pull-requests: ${pulls.map((v) => v.number).join(", ")}`);
 
     const promises = pulls
       .map(async (pull) => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -68,7 +68,9 @@ async function preCheck(context: ContextPlugin) {
   const { payload, octokit, logger } = context;
 
   const issue = parseGitHubUrl(payload.issue.html_url);
-  const linkedPulls = await collectLinkedMergedPulls(context, issue);
+  const linkedPulls = (await collectLinkedMergedPulls(context, issue)).filter((pullRequest) =>
+    context.payload.issue.assignees.map((assignee) => assignee?.login).includes(pullRequest.author.login)
+  );
   logger.debug("Checking open linked pull-requests for", {
     issue,
     linkedPulls,

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -38,6 +38,7 @@ jest.unstable_mockModule("../src/data-collection/collect-linked-pulls", () => ({
         login: "gitcoindev",
         id: 88761781,
       },
+      state: "MERGED",
       repository: {
         owner: {
           login: "ubiquity-os",
@@ -63,6 +64,12 @@ describe("Action tests", () => {
             html_url: "https://github.com/ubiquity-os/comment-incentives/issues/22",
             number: 1,
             state_reason: "not_planned",
+            assignees: [
+              {
+                id: 1,
+                login: "gentlementlegen",
+              },
+            ],
           },
           repository: {
             name: "conversation-rewards",
@@ -96,6 +103,12 @@ describe("Action tests", () => {
             html_url: "https://github.com/ubiquity-os/comment-incentives/issues/22",
             number: 1,
             state_reason: "completed",
+            assignees: [
+              {
+                id: 1,
+                login: "gentlementlegen",
+              },
+            ],
           },
           repository: {
             name: "conversation-rewards",

--- a/tests/fees.test.ts
+++ b/tests/fees.test.ts
@@ -37,6 +37,16 @@ describe("GithubCommentModule Fee Tests", () => {
           html_url: issueUrl,
           number: 69,
           state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+            {
+              id: 2,
+              login: "0x4007",
+            },
+          ],
         },
         repository: {
           name: "conversation-rewards",

--- a/tests/get-activity.test.ts
+++ b/tests/get-activity.test.ts
@@ -21,6 +21,26 @@ describe("GetActivity class", () => {
       config: cfg,
       logger: new Logs("debug"),
       octokit: new Octokit({ auth: process.env.GITHUB_TOKEN }),
+      payload: {
+        issue: {
+          html_url: issueUrl,
+          number: 1,
+          state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+          ],
+        },
+        repository: {
+          name: "text-conversation-rewards",
+          owner: {
+            login: "ubiquity-os-marketplace",
+            id: 76412717,
+          },
+        },
+      },
     } as unknown as ContextPlugin,
     issue
   );

--- a/tests/parser/permit-generation-module.test.ts
+++ b/tests/parser/permit-generation-module.test.ts
@@ -21,6 +21,12 @@ const ctx = {
       html_url: "https://github.com/ubiquity-os/comment-incentives/issues/22",
       number: 1,
       state_reason: "not_planned",
+      assignees: [
+        {
+          id: 1,
+          login: "gentlementlegen",
+        },
+      ],
     },
     repository: {
       name: "conversation-rewards",

--- a/tests/permit-generatable.test.ts
+++ b/tests/permit-generatable.test.ts
@@ -58,6 +58,12 @@ const ctx = {
       html_url: "https://github.com/ubiquity-os/conversation-rewards/issues/5",
       number: 1,
       state_reason: "completed",
+      assignees: [
+        {
+          id: 1,
+          login: "gentlementlegen",
+        },
+      ],
     },
     repository: {
       name: "conversation-rewards",
@@ -145,6 +151,7 @@ jest.unstable_mockModule("../src/data-collection/collect-linked-pulls", () => ({
         login: "gentlementlegen",
         id: 9807008,
       },
+      state: "MERGED",
       repository: {
         owner: {
           login: "ubiquity-os",

--- a/tests/pre-check.test.ts
+++ b/tests/pre-check.test.ts
@@ -95,6 +95,16 @@ describe("Pre-check tests", () => {
           html_url: issueUrl,
           number: 1,
           state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+            {
+              id: 2,
+              login: "0x4007",
+            },
+          ],
         },
         repository: {
           name: "conversation-rewards",
@@ -138,6 +148,16 @@ describe("Pre-check tests", () => {
           html_url: issueUrl,
           number: 1,
           state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+            {
+              id: 2,
+              login: "0x4007",
+            },
+          ],
         },
         repository: {
           name: "conversation-rewards",
@@ -167,6 +187,21 @@ describe("Pre-check tests", () => {
     }));
     const ctx = {
       payload: {
+        issue: {
+          html_url: issueUrl,
+          number: 1,
+          state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+            {
+              id: 2,
+              login: "0x4007",
+            },
+          ],
+        },
         sender: {
           login: "ubiquity-os",
         },

--- a/tests/price-label.test.ts
+++ b/tests/price-label.test.ts
@@ -51,6 +51,12 @@ describe("Price tests", () => {
           html_url: "https://github.com/ubiquity-os/comment-incentives/issues/22",
           number: 1,
           state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+          ],
         },
         repository: {
           name: "conversation-rewards",

--- a/tests/process.issue.test.ts
+++ b/tests/process.issue.test.ts
@@ -55,6 +55,12 @@ const ctx = {
       html_url: "https://github.com/ubiquity-os/conversation-rewards/issues/5",
       number: 1,
       state_reason: "completed",
+      assignees: [
+        {
+          id: 1,
+          login: "gentlementlegen",
+        },
+      ],
     },
     repository: {
       name: "conversation-rewards",
@@ -142,6 +148,7 @@ jest.unstable_mockModule("../src/data-collection/collect-linked-pulls", () => ({
         login: "gentlementlegen",
         id: 9807008,
       },
+      state: "MERGED",
       repository: {
         owner: {
           login: "ubiquity-os",

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -51,6 +51,7 @@ const ctx = {
       html_url: issueUrl,
       number: 13,
       state_reason: "completed",
+      assignees: [],
     },
     repository: {
       name: "conversation-rewards",

--- a/tests/rewards.test.ts
+++ b/tests/rewards.test.ts
@@ -106,6 +106,7 @@ jest.unstable_mockModule("../src/data-collection/collect-linked-pulls", () => ({
         login: "0x4007",
         id: 4975670,
       },
+      state: "MERGED",
       repository: {
         owner: {
           login: "ubiquity",
@@ -155,6 +156,16 @@ describe("Rewards tests", () => {
         html_url: issueUrl,
         number: 69,
         state_reason: "completed",
+        assignees: [
+          {
+            id: 1,
+            login: "gentlementlegen",
+          },
+          {
+            id: 2,
+            login: "0x4007",
+          },
+        ],
       },
       repository: {
         name: "conversation-rewards",

--- a/tests/truncate-data.test.ts
+++ b/tests/truncate-data.test.ts
@@ -108,6 +108,16 @@ describe("Payload truncate tests", () => {
           html_url: issueUrl,
           number: 1,
           state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+            {
+              id: 2,
+              login: "0x4007",
+            },
+          ],
         },
         repository: {
           name: "conversation-rewards",
@@ -138,6 +148,18 @@ describe("Payload truncate tests", () => {
                         id: "PR_kwDOKzVPS85zXUok",
                         title: "fix: add state to sorting manager for bottom and top 2",
                         number: 71,
+                        url: "https://github.com/ubiquity/work.ubq.fi/pull/71",
+                        state: "MERGED",
+                        author: {
+                          login: "0x4007",
+                          id: 4975670,
+                        },
+                        repository: {
+                          owner: {
+                            login: "ubiquity",
+                          },
+                          name: "work.ubq.fi",
+                        },
                       },
                     },
                   ],


### PR DESCRIPTION
Resolves #249 

QA: https://github.com/ubiquibot-whilefoo-testing/testing/issues/8#issuecomment-2616612895

What happened was that before #218 was merged, `collectLinkedMergedPulls` returned all PRs even the ones that are not merged even though the name implies that only merged PRs are returned. #218 fixed that `collectLinkedMergedPulls` only returned merged PRs. This change however breaks pre-check functionality because it won't detect open PRs so it won't stop the plugin.

What I changed:
- `collectLinkedMergedPulls` returns all PRs
- Pre-check filters PRs that are not issue assignees and checks if any of them are open, and stop execution if there is any
- `IssueActivity` now filters only merged PRs from issue assignees
- Changes requested by @0x4007 in #218

If you guys agree with this approach, I will also change `collectLinkedMergedPulls` to `collectLinkedPulls` to better reflect what the function does.