### PR TITLE
fix: node batch

### DIFF
--- a/src/helpers/get-comment-details.ts
+++ b/src/helpers/get-comment-details.ts
@@ -5,17 +5,26 @@ import { QUERY_COMMENT_DETAILS } from "../types/requests";
 
 export async function getMinimizedCommentStatus(context: ContextPlugin, comments: GitHubIssueComment[]) {
   const { octokit } = context;
-  const commentsData = await octokit.graphql<{ nodes?: IssueComment[] }>(QUERY_COMMENT_DETAILS, {
-    node_ids: comments.map((o) => o.node_id),
-  });
+  // 100 is the maximum amount of nodes that can be passed to the gql request, anything above will crash it.
+  const CHUNK_SIZE = 100;
+  const commentNodes: IssueComment[] = [];
 
-  if (commentsData?.nodes?.length) {
-    for (const commentNode of commentsData.nodes) {
-      const comment = comments.find((o) => o.node_id === commentNode.id);
-      // For each comment we add the 'isMinimized' info, which corresponds to a collapsed comment
-      if (comment) {
-        comment.isMinimized = commentNode.isMinimized;
-      }
+  for (let i = 0; i < comments.length; i += CHUNK_SIZE) {
+    const chunk = comments.slice(i, i + CHUNK_SIZE);
+
+    const commentsData = await octokit.graphql<{ nodes?: IssueComment[] }>(QUERY_COMMENT_DETAILS, {
+      node_ids: chunk.map((o) => o.node_id),
+    });
+
+    if (commentsData?.nodes?.length) {
+      commentNodes.push(...commentsData.nodes);
+    }
+  }
+
+  for (const commentNode of commentNodes) {
+    const comment = comments.find((o) => o.node_id === commentNode.id);
+    if (comment) {
+      comment.isMinimized = commentNode.isMinimized;
     }
   }
 }


### PR DESCRIPTION
Resolves #187

QA:

Before fix
<img width="1125" alt="image" src="https://github.com/user-attachments/assets/16e00e92-ffda-4ecf-b633-c021196bbb6a" />

```
        ⚠ Could not fetch issue data: GraphqlResponseError: Request failed due to following response errors:
           - You may not provide more than 100 node ids; you provided 152.
```

After fix

<img width="1103" alt="image" src="https://github.com/user-attachments/assets/be9cb520-fb2d-48ce-9d46-9edc0f9044df" />


<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
