### PR TITLE
fix: malformed urls do not crash the run anymore

### DIFF
--- a/src/helpers/urls.ts
+++ b/src/helpers/urls.ts
@@ -1,6 +1,10 @@
 function getBaseUrl(url: string) {
-  const urlObject = new URL(url);
-  return `${urlObject.protocol}//${urlObject.host}${urlObject.pathname}`;
+  try {
+    const urlObject = new URL(url);
+    return `${urlObject.protocol}//${urlObject.host}${urlObject.pathname}`;
+  } catch {
+    return url;
+  }
 }
 
 export function areBaseUrlsEqual(url1: string, url2: string) {

--- a/tests/truncate-data.test.ts
+++ b/tests/truncate-data.test.ts
@@ -8,6 +8,7 @@ import { db } from "./__mocks__/db";
 import dbSeed from "./__mocks__/db-seed.json";
 import { server } from "./__mocks__/node";
 import cfg from "./__mocks__/results/valid-configuration.json";
+import { areBaseUrlsEqual } from "../src/helpers/urls";
 
 const issueUrl = "https://github.com/ubiquity/work.ubq.fi/issues/69";
 
@@ -223,5 +224,11 @@ describe("Payload truncate tests", () => {
       expect.anything(),
       expect.objectContaining({ node_ids: Array.from({ length: 50 }, (v, k) => k + 100) })
     );
+  });
+
+  it("Should compare urls and handle ill-formed strings", () => {
+    expect(areBaseUrlsEqual("https://localhost/home", "https://localhost/home#1234")).toBeTruthy();
+    expect(areBaseUrlsEqual("https://localhost/home", "https://localhost/page")).toBeFalsy();
+    expect(areBaseUrlsEqual("ubq.fi", "pay.ubq.fi")).toBeFalsy();
   });
 });


### PR DESCRIPTION
Resolves #313

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
