### PR TITLE
fix: gitattributes gets defaults if no file is found

### DIFF
--- a/src/helpers/excluded-files.ts
+++ b/src/helpers/excluded-files.ts
@@ -119,11 +119,11 @@ async function getFileContent(
     return null;
   } catch (err) {
     if (err instanceof Error && "status" in err && err.status === 404) {
-      context.logger.info(
-        `.gitattributes was not found for ${context.payload.repository.owner.login}/${context.payload.repository.name}`
-      );
+      context.logger.info(`[${path}] was not found for ${owner}/${repo}`, { err });
       return null;
     }
-    throw context.logger.error(`Error fetching files to be excluded ${err}`);
+    throw context.logger.error(`Could not fetch the list of files to be excluded.`, {
+      err,
+    });
   }
 }

--- a/src/helpers/excluded-files.ts
+++ b/src/helpers/excluded-files.ts
@@ -33,10 +33,12 @@ async function parseGitAttributes(content: string): Promise<GitAttributes[]> {
     .filter((item): item is GitAttributes => item !== null);
 }
 
+const DEFAULT_EXCLUDED_PATTERNS = ["dist/**", "*.lockb", "*.lock", "tests/__mocks__/"];
+
 export async function getExcludedFiles(context: ContextPlugin, owner: string, repo: string, ref?: string) {
   const gitAttributesContent = await getFileContent(context, owner, repo, ".gitattributes", ref);
   if (!gitAttributesContent) {
-    return null;
+    return DEFAULT_EXCLUDED_PATTERNS;
   }
   const gitAttributesLinguistGenerated = (await parseGitAttributes(gitAttributesContent))
     .filter((v) => v.attributes["linguist-generated"])

--- a/src/helpers/excluded-files.ts
+++ b/src/helpers/excluded-files.ts
@@ -33,7 +33,7 @@ async function parseGitAttributes(content: string): Promise<GitAttributes[]> {
     .filter((item): item is GitAttributes => item !== null);
 }
 
-const DEFAULT_EXCLUDED_PATTERNS = ["dist/**", "*.lockb", "*.lock", "tests/__mocks__/"];
+const DEFAULT_EXCLUDED_PATTERNS = ["dist/**", "*.lockb", "*.lock", "tests/__mocks__/", "bin/"];
 
 function parsePrettierIgnore(content: string): string[] {
   return content

--- a/src/helpers/excluded-files.ts
+++ b/src/helpers/excluded-files.ts
@@ -43,24 +43,15 @@ function parsePrettierIgnore(content: string): string[] {
 }
 
 function parseTsConfigExclude(content: string): string[] {
-  const patterns: string[] = [];
   try {
-    const excludeRegex = /"exclude"\s*:\s*\[([^\]]*)\]/;
-    const match = RegExp(excludeRegex).exec(content);
-    if (match && match[1]) {
-      const excludeContent = match[1];
-      const stringLiteralRegex = /"([^"]*)"/g;
-      let stringMatch;
-      while ((stringMatch = stringLiteralRegex.exec(excludeContent)) !== null) {
-        if (stringMatch[1]) {
-          patterns.push(stringMatch[1]);
-        }
-      }
+    const tsConfig = JSON.parse(content) as { exclude: string[] };
+    if (tsConfig.exclude?.length) {
+      return tsConfig.exclude;
     }
+    return [];
   } catch {
-    // Silently ignore parsing errors, returning patterns found so far
+    return [];
   }
-  return patterns;
 }
 
 export async function getExcludedFiles(

--- a/src/helpers/excluded-files.ts
+++ b/src/helpers/excluded-files.ts
@@ -33,7 +33,7 @@ async function parseGitAttributes(content: string): Promise<GitAttributes[]> {
     .filter((item): item is GitAttributes => item !== null);
 }
 
-const DEFAULT_EXCLUDED_PATTERNS = ["dist/**", "*.lockb", "*.lock", "tests/__mocks__/", "bin/"];
+const DEFAULT_EXCLUDED_PATTERNS = ["dist/**", "*.lockb", "*.lock", "tests/__mocks__/", "bin/", "package-lock.json"];
 
 function parsePrettierIgnore(content: string): string[] {
   return content

--- a/src/helpers/excluded-files.ts
+++ b/src/helpers/excluded-files.ts
@@ -43,15 +43,24 @@ function parsePrettierIgnore(content: string): string[] {
 }
 
 function parseTsConfigExclude(content: string): string[] {
+  const patterns: string[] = [];
   try {
-    const tsConfig = JSON.parse(content) as { exclude: string[] };
-    if (tsConfig.exclude?.length) {
-      return tsConfig.exclude;
+    const excludeRegex = /"exclude"\s*:\s*\[([^\]]*)\]/;
+    const match = RegExp(excludeRegex).exec(content);
+    if (match && match[1]) {
+      const excludeContent = match[1];
+      const stringLiteralRegex = /"([^"]*)"/g;
+      let stringMatch;
+      while ((stringMatch = stringLiteralRegex.exec(excludeContent)) !== null) {
+        if (stringMatch[1]) {
+          patterns.push(stringMatch[1]);
+        }
+      }
     }
-    return [];
   } catch {
-    return [];
+    // Silently ignore parsing errors, returning patterns found so far
   }
+  return patterns;
 }
 
 export async function getExcludedFiles(

--- a/src/parser/review-incentivizer-module.ts
+++ b/src/parser/review-incentivizer-module.ts
@@ -103,7 +103,15 @@ export class ReviewIncentivizerModule extends BaseModule {
     const diff = await this.getTripleDotDiffAsObject(owner, repo, baseSha, headSha);
     const reviewEffect = { addition: 0, deletion: 0 };
     for (const [fileName, changes] of Object.entries(diff)) {
-      if (!excludedFilePatterns?.length || !excludedFilePatterns.some((pattern) => minimatch(fileName, pattern))) {
+      if (
+        !excludedFilePatterns?.length ||
+        !excludedFilePatterns.some((pattern) => {
+          // Adjust pattern to handle directories: append '**' if pattern ends with '/' otherwise minimatch doesn't
+          // exclude the files within the subdirectories
+          const adjustedPattern = pattern.endsWith("/") ? `${pattern}**` : pattern;
+          return minimatch(fileName, adjustedPattern);
+        })
+      ) {
         reviewEffect.addition += changes.addition;
         reviewEffect.deletion += changes.deletion;
       }

--- a/tests/file-exclusion.test.ts
+++ b/tests/file-exclusion.test.ts
@@ -12,11 +12,11 @@ type MockGetContent = jest.Mock<
   ) => Promise<OctokitResponse<unknown>>
 >;
 
-const mockGetContentFunction: MockGetContent = jest.fn();
+const mockGetContent: MockGetContent = jest.fn();
 const mockOctokit = {
   rest: {
     repos: {
-      getContent: mockGetContentFunction,
+      getContent: mockGetContent,
     },
   },
 };
@@ -27,8 +27,6 @@ const ctx = {
   octokit: mockOctokit,
   payload: { repository: { owner: { login: "test-owner" }, name: "test-repo" } },
 } as unknown as ContextPlugin;
-
-const mockGetContent: MockGetContent = mockGetContentFunction;
 
 const { ReviewIncentivizerModule } = await import("../src/parser/review-incentivizer-module");
 
@@ -76,7 +74,7 @@ function mockFileResponse(content: string): Promise<OctokitResponse<unknown>> {
 }
 
 function mockNotFoundError(): Promise<never> {
-  const error = new Error("Not Found") as Error & { status?: number }; // Add type assertion
+  const error = new Error("Not Found") as Error & { status?: number };
   error.status = 404;
   return Promise.reject(error);
 }

--- a/tests/file-exclusion.test.ts
+++ b/tests/file-exclusion.test.ts
@@ -1,44 +1,60 @@
-import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { OctokitResponse, RequestParameters } from "@octokit/types";
 import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { getExcludedFiles } from "../src/helpers/excluded-files";
 import { ContextPlugin } from "../src/types/plugin-input";
 import { server } from "./__mocks__/node";
 import cfg from "./__mocks__/results/valid-configuration.json";
-import { customOctokit as Octokit } from "@ubiquity-os/plugin-sdk/octokit";
+
+type MockGetContent = jest.Mock<
+  (
+    params?: RequestParameters & { ref?: string; owner: string; repo: string; path: string }
+  ) => Promise<OctokitResponse<unknown>>
+>;
+
+const mockGetContentFunction: MockGetContent = jest.fn();
+const mockOctokit = {
+  rest: {
+    repos: {
+      getContent: mockGetContentFunction,
+    },
+  },
+};
 
 const ctx = {
   config: cfg,
   logger: new Logs("debug"),
-  octokit: new Octokit({ auth: process.env.GITHUB_TOKEN }),
+  octokit: mockOctokit,
+  payload: { repository: { owner: { login: "test-owner" }, name: "test-repo" } },
 } as unknown as ContextPlugin;
+
+const mockGetContent: MockGetContent = mockGetContentFunction;
 
 const { ReviewIncentivizerModule } = await import("../src/parser/review-incentivizer-module");
 
 beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  mockGetContent.mockClear();
+});
 afterAll(() => server.close());
 
-describe("Modules tests", () => {
+describe("ReviewIncentivizerModule file exclusion", () => {
   const reviewIncentivizer = new ReviewIncentivizerModule(ctx);
 
-  beforeEach(async () => {
-    jest.spyOn(ReviewIncentivizerModule.prototype, "getTripleDotDiffAsObject").mockImplementation(() => {
-      return Promise.resolve({
-        "src/index.ts": { addition: 50, deletion: 50 },
-        "src/helpers/utils.ts": { addition: 50, deletion: 50 },
-        "dist/generated.ts": { addition: 50, deletion: 50 },
-        "dist/lang_generated.ts": { addition: 50, deletion: 50 },
-        "tests/main.test.ts": { addition: 50, deletion: 50 },
-      });
+  beforeEach(() => {
+    jest.spyOn(ReviewIncentivizerModule.prototype, "getTripleDotDiffAsObject").mockResolvedValue({
+      "src/index.ts": { addition: 50, deletion: 50 },
+      "src/helpers/utils.ts": { addition: 50, deletion: 50 },
+      "dist/generated.ts": { addition: 50, deletion: 50 },
+      "dist/lang_generated.ts": { addition: 50, deletion: 50 },
+      "tests/main.test.ts": { addition: 50, deletion: 50 },
     });
   });
 
   it("should calculate total diff when no patterns are excluded", async () => {
     const result = await reviewIncentivizer.getReviewableDiff("owner", "repo", "baseSha", "headSha");
-
-    expect(result).toEqual({
-      addition: 250,
-      deletion: 250,
-    });
+    expect(result).toEqual({ addition: 250, deletion: 250 });
   });
 
   it("should exclude files matching ANY of the patterns", async () => {
@@ -46,9 +62,128 @@ describe("Modules tests", () => {
       "dist/**",
       "tests/**",
     ]);
-    expect(result).toEqual({
-      addition: 100,
-      deletion: 100,
+    expect(result).toEqual({ addition: 100, deletion: 100 });
+  });
+});
+
+function mockFileResponse(content: string): Promise<OctokitResponse<unknown>> {
+  return Promise.resolve({
+    status: 200,
+    headers: {},
+    url: "mock://url",
+    data: { content: Buffer.from(content).toString("base64") },
+  });
+}
+
+function mockNotFoundError(): Promise<never> {
+  const error = new Error("Not Found") as Error & { status?: number }; // Add type assertion
+  error.status = 404;
+  return Promise.reject(error);
+}
+
+describe("getExcludedFiles tests", () => {
+  const owner = "test-owner";
+  const repo = "test-repo";
+  const defaults = ["dist/**", "*.lockb", "*.lock", "tests/__mocks__/"];
+
+  it("should return defaults if no files are found", async () => {
+    mockGetContent.mockImplementation(mockNotFoundError);
+    const result = await getExcludedFiles(ctx, owner, repo);
+    expect(result).toEqual(defaults);
+    expect(mockGetContent).toHaveBeenCalledTimes(3);
+  });
+
+  it("should return defaults + gitattributes patterns", async () => {
+    const gitAttribContent = `
+      *.ts linguist-generated
+      *.js linguist-vendored
+      # comment
+      dist/ linguist-generated
+    `;
+    mockGetContent.mockImplementation((params) => {
+      if (params?.path === ".gitattributes") return mockFileResponse(gitAttribContent);
+      return mockNotFoundError();
     });
+    const result = await getExcludedFiles(ctx, owner, repo);
+    expect(new Set(result)).toEqual(new Set([...defaults, "*.ts", "dist/"]));
+    expect(result).toHaveLength(defaults.length + 2);
+  });
+
+  it("should return defaults + prettierignore patterns", async () => {
+    const prettierIgnoreContent = `
+      # Prettier ignores
+      node_modules
+      *.log
+
+      build/
+    `;
+    mockGetContent.mockImplementation((params) => {
+      if (params?.path === ".prettierignore") return mockFileResponse(prettierIgnoreContent);
+      return mockNotFoundError();
+    });
+    const result = await getExcludedFiles(ctx, owner, repo);
+    expect(new Set(result)).toEqual(new Set([...defaults, "node_modules", "*.log", "build/"]));
+    expect(result).toHaveLength(defaults.length + 3);
+  });
+
+  it("should return defaults + tsconfig exclude patterns", async () => {
+    const tsconfigContent = `
+      {
+        "compilerOptions": {
+          "target": "ES2022"
+        },
+        // comments here
+        "exclude": [
+          "node_modules", // more comments
+          "dist",
+          "**/*.spec.ts"
+        ]
+      }
+    `;
+    mockGetContent.mockImplementation((params) => {
+      if (params?.path === "tsconfig.json") return mockFileResponse(tsconfigContent);
+      return mockNotFoundError();
+    });
+    const result = await getExcludedFiles(ctx, owner, repo);
+    expect(new Set(result)).toEqual(new Set([...defaults, "node_modules", "dist", "**/*.spec.ts"]));
+    expect(result).toHaveLength(defaults.length + 3);
+  });
+
+  it("should merge and deduplicate patterns from all sources", async () => {
+    const gitAttribContent = "*.gen.ts linguist-generated\ndist/** linguist-generated";
+    const prettierIgnoreContent = "build/\n*.lock";
+    const tsconfigContent = `{ "exclude": ["coverage", "build/"] }`;
+
+    mockGetContent.mockImplementation((params) => {
+      if (params?.path === ".gitattributes") return mockFileResponse(gitAttribContent);
+      if (params?.path === ".prettierignore") return mockFileResponse(prettierIgnoreContent);
+      if (params?.path === "tsconfig.json") return mockFileResponse(tsconfigContent);
+      return mockNotFoundError();
+    });
+
+    const result = await getExcludedFiles(ctx, owner, repo);
+    const expected = [...new Set([...defaults, "*.gen.ts", "build/", "coverage"])];
+    expect(new Set(result)).toEqual(new Set(expected));
+    expect(result).toHaveLength(expected.length);
+  });
+
+  it("should handle tsconfig without exclude array", async () => {
+    const tsconfigContent = `{ "compilerOptions": {} }`;
+    mockGetContent.mockImplementation((params) => {
+      if (params?.path === "tsconfig.json") return mockFileResponse(tsconfigContent);
+      return mockNotFoundError();
+    });
+    const result = await getExcludedFiles(ctx, owner, repo);
+    expect(result).toEqual(defaults);
+  });
+
+  it("should handle invalid tsconfig json gracefully", async () => {
+    const tsconfigContent = `{ "compilerOptions": { "exclude": [,] }`;
+    mockGetContent.mockImplementation((params) => {
+      if (params?.path === "tsconfig.json") return mockFileResponse(tsconfigContent);
+      return mockNotFoundError();
+    });
+    const result = await getExcludedFiles(ctx, owner, repo);
+    expect(result).toEqual(defaults);
   });
 });

--- a/tests/file-exclusion.test.ts
+++ b/tests/file-exclusion.test.ts
@@ -82,7 +82,7 @@ function mockNotFoundError(): Promise<never> {
 describe("getExcludedFiles tests", () => {
   const owner = "test-owner";
   const repo = "test-repo";
-  const defaults = ["dist/**", "*.lockb", "*.lock", "tests/__mocks__/"];
+  const defaults = ["dist/**", "*.lockb", "*.lock", "tests/__mocks__/", "bin/", "package-lock.json"];
 
   it("should return defaults if no files are found", async () => {
     mockGetContent.mockImplementation(mockNotFoundError);
@@ -143,7 +143,7 @@ describe("getExcludedFiles tests", () => {
       return mockNotFoundError();
     });
     const result = await getExcludedFiles(ctx, owner, repo);
-    expect(new Set(result)).toEqual(new Set([...defaults, "node_modules", "dist", "**/*.spec.ts"]));
+    expect(new Set(result)).toEqual(new Set([...defaults, "node_modules", "dist", "**/*.spec.ts", "bin/"]));
     expect(result).toHaveLength(defaults.length + 3);
   });
 


### PR DESCRIPTION
Helps to get default values if no `.gitattributes` file is found, which I believe are safe to be always ignored. Can be overridden by the repo's own `.gitattributes` file.

Resolves https://github.com/ubiquity/business-development/issues/152 (helps to generate more accurate results)

Resolves #331 

QA:
<img width="731" alt="image" src="https://github.com/user-attachments/assets/efc6edc7-a2cb-4b2e-b280-84914dba3b9f" />
(before the fix the reward was around 9000)

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
