### PR TITLE
fix: prompt improvement

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -394,10 +394,7 @@ export class ContentEvaluatorModule extends BaseModule {
       });
 
       // Strip any potential Markdown formatting like ```json or ``` from the response, because some LLMs love do to so
-      const rawResponse = String(res.choices[0].message.content)
-        .replace(/^```json\s*/, "")
-        .replace(/^```\s*/, "")
-        .replace(/\s*```$/, "");
+      const rawResponse = String(res.choices[0].message.content).replace(/^.*?{/, "{").replace(/}.*$/, "}");
 
       this.context.logger.info(`LLM raw response (using max_tokens: ${maxTokens}): ${rawResponse}`);
 

--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -172,7 +172,7 @@ export class ContentEvaluatorModule extends BaseModule {
     );
 
     for (const currentComment of commentsWithScore) {
-      let currentRelevance = 1;
+      let currentRelevance = 1; // For comments not in fixed relevance types and missed by OpenAI evaluation
       if (this._fixedRelevances[currentComment.commentType]) {
         currentRelevance = this._fixedRelevances[currentComment.commentType];
       } else if (!isNaN(relevancesByAi[currentComment.id])) {

--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -165,6 +165,7 @@ export class ContentEvaluatorModule extends BaseModule {
               return Number.isFinite(retryAfter) ? retryAfter : true;
             }
           }
+          // Retry if there is a SyntaxError caused by malformed JSON or TypeBoxError caused by incorrect JSON from OpenAI
           return error instanceof SyntaxError || error instanceof TypeBoxError || error instanceof LogReturn;
         },
       }
@@ -180,6 +181,7 @@ export class ContentEvaluatorModule extends BaseModule {
 
       const currentReward = new Decimal(currentComment.score?.reward ?? 0);
       const priority =
+        // We do not apply priority multiplier on issue specification
         currentComment.score?.priority && !(currentComment.commentType & CommentAssociation.SPECIFICATION)
           ? currentComment.score.priority
           : 1;

--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -165,14 +165,13 @@ export class ContentEvaluatorModule extends BaseModule {
               return Number.isFinite(retryAfter) ? retryAfter : true;
             }
           }
-          // Retry if there is a SyntaxError caused by malformed JSON or TypeBoxError caused by incorrect JSON from OpenAI
           return error instanceof SyntaxError || error instanceof TypeBoxError || error instanceof LogReturn;
         },
       }
     );
 
     for (const currentComment of commentsWithScore) {
-      let currentRelevance = 1; // For comments not in fixed relevance types and missed by OpenAI evaluation
+      let currentRelevance = 1;
       if (this._fixedRelevances[currentComment.commentType]) {
         currentRelevance = this._fixedRelevances[currentComment.commentType];
       } else if (!isNaN(relevancesByAi[currentComment.id])) {
@@ -181,7 +180,6 @@ export class ContentEvaluatorModule extends BaseModule {
 
       const currentReward = new Decimal(currentComment.score?.reward ?? 0);
       const priority =
-        // We do not apply priority multiplier on issue specification
         currentComment.score?.priority && !(currentComment.commentType & CommentAssociation.SPECIFICATION)
           ? currentComment.score.priority
           : 1;
@@ -392,7 +390,13 @@ export class ContentEvaluatorModule extends BaseModule {
         frequency_penalty: 0,
         presence_penalty: 0,
       });
-      const rawResponse = String(res.choices[0].message.content);
+
+      // Strip any potential Markdown formatting like ```json or ``` from the response, because some LLMs love do to so
+      const rawResponse = String(res.choices[0].message.content)
+        .replace(/^```json\s*/, "")
+        .replace(/^```\s*/, "")
+        .replace(/\s*```$/, "");
+
       this.context.logger.info(`LLM raw response (using max_tokens: ${maxTokens}): ${rawResponse}`);
 
       const relevances = Value.Decode(openAiRelevanceResponseSchema, JSON.parse(rawResponse));
@@ -412,8 +416,12 @@ export class ContentEvaluatorModule extends BaseModule {
     }
     const allCommentsMap = allComments.map((value) => `${value.id} - ${value.author}: "${value.comment}"`);
     const userCommentsMap = userComments.map((value) => `${value.id}: "${value.comment}"`);
+
     return `
+      CRITICAL REQUIREMENT: YOUR RESPONSE MUST BE RAW JSON ONLY - NO BACKTICKS, NO CODE BLOCKS, NO MARKDOWN.
+      
       Evaluate the relevance of GitHub comments to an issue. Provide a raw JSON object with comment IDs and their relevance scores.
+
       Issue: ${issue}
 
       All comments:
@@ -445,7 +453,7 @@ export class ContentEvaluatorModule extends BaseModule {
 
       Example Output Format: {"commentId1": 0.75, "commentId2": 0.3, "commentId3": 0.9}
 
-      IMPORTANT: Your response MUST be ONLY the raw JSON object, suitable for direct parsing by a program. Do not include any explanatory text, markdown formatting, backticks, or code blocks.
+      YOUR RESPONSE MUST CONTAIN ONLY THE RAW JSON OBJECT WITH NO FORMATTING, NO EXPLANATION, NO BACKTICKS, NO CODE BLOCKS.
     `;
   }
 
@@ -453,7 +461,9 @@ export class ContentEvaluatorModule extends BaseModule {
     if (!issue?.length) {
       throw new Error("Issue specification comment is missing or empty");
     }
-    return `I need to evaluate the value of a GitHub contributor's comments in a pull request. 
+    return `CRITICAL REQUIREMENT: YOUR RESPONSE MUST BE RAW JSON ONLY - NO BACKTICKS, NO CODE BLOCKS, NO MARKDOWN.
+
+    I need to evaluate the value of a GitHub contributor's comments in a pull request. 
     Some of these comments are code review comments, and some are general suggestions or a part of the discussion. 
     I'm interested in how much each comment helps to solve the GitHub issue and improve code quality. 
     Please provide a float between 0 and 1 to represent the value of each comment. 
@@ -461,9 +471,7 @@ export class ContentEvaluatorModule extends BaseModule {
     A stringified JSON is given below that contains the specification of the GitHub issue, and comments by different contributors. 
     The property "diffHunk" presents the chunk of code being addressed for a possible change in a code review comment. 
     
-    \`\`\`
     ${JSON.stringify({ specification: issue, comments: userComments })}
-    \`\`\`\
   
     To what degree are each of the comments valuable? 
     Please reply with ONLY a raw JSON object where each key is the comment ID given in JSON above, and the value is a float number between 0 and 1 corresponding to the comment. 
@@ -471,6 +479,7 @@ export class ContentEvaluatorModule extends BaseModule {
 
     Example Output Format: {"commentId1": 0.75, "commentId2": 0.3, "commentId3": 0.9}
     
-    IMPORTANT: Your response MUST be ONLY the raw JSON object, suitable for direct parsing by a program. Do not include any explanatory text, markdown formatting, backticks, or code blocks.`;
+    YOUR RESPONSE MUST CONTAIN ONLY THE RAW JSON OBJECT WITH NO FORMATTING, NO EXPLANATION, NO BACKTICKS, NO CODE BLOCKS.
+`;
   }
 }

--- a/src/parser/simplification-incentivizer-module.ts
+++ b/src/parser/simplification-incentivizer-module.ts
@@ -1,14 +1,18 @@
+import { RestEndpointMethodTypes } from "@octokit/rest";
 import { Value } from "@sinclair/typebox/value";
-import { IssueActivity } from "../issue-activity";
-import { BaseModule } from "../types/module";
-import { ContextPlugin } from "../types/plugin-input";
-import { Result } from "../types/results";
+import { minimatch } from "minimatch";
 import {
   SimplificationIncentivizerConfiguration,
   simplificationIncentivizerConfigurationType,
 } from "../configuration/simplification-incentivizer-config";
+import { GitHubPullRequest } from "../github-types";
 import { getExcludedFiles } from "../helpers/excluded-files";
-import { minimatch } from "minimatch";
+import { IssueActivity } from "../issue-activity";
+import { BaseModule } from "../types/module";
+import { ContextPlugin } from "../types/plugin-input";
+import { Result } from "../types/results";
+
+type GitHubPullRequestFile = RestEndpointMethodTypes["pulls"]["listFiles"]["response"]["data"][0];
 
 export class SimplificationIncentivizerModule extends BaseModule {
   private readonly _configuration: SimplificationIncentivizerConfiguration | null =
@@ -23,50 +27,69 @@ export class SimplificationIncentivizerModule extends BaseModule {
   async transform(data: Readonly<IssueActivity>, result: Result) {
     const linkedPullRequests = data.linkedReviews.map((review) => review.self);
     if (!linkedPullRequests.length) {
-      this.context.logger.warn(`No pull request is linked to this issue, won't run SimplificationIncentivizer`);
+      this.context.logger.warn("No pull request is linked to this issue, won't run SimplificationIncentivizer");
       return result;
     }
     const prNumbers = linkedPullRequests.map((pull) => pull?.number);
-    this.context.logger.info("Pull requests linked to this issue", { prNumbers });
 
+    this.context.logger.info("Pull requests linked to this issue", { prNumbers });
     for (const pull of linkedPullRequests) {
       if (!pull?.head.repo) continue;
-      const excludedFilePatterns = await getExcludedFiles(
-        this.context,
-        pull.head.repo.owner.login,
-        pull.head.repo.name
-      );
-      const prAuthor = pull.user.login;
+      result = await this._processPullRequest(pull as GitHubPullRequest, result);
+    }
+    return result;
+  }
+
+  private async _processPullRequest(pull: GitHubPullRequest, result: Result) {
+    const excludedFilePatterns = await getExcludedFiles(this.context, pull.base.repo.owner.login, pull.base.repo.name);
+    const prAuthor = pull.user.login;
+    try {
       const files = await this.context.octokit.rest.pulls.listFiles({
-        owner: pull.head.repo.owner.login,
-        repo: pull.head.repo.name,
+        owner: pull.base.repo.owner.login,
+        repo: pull.base.repo.name,
         pull_number: pull.number,
       });
-
       for (const file of files.data) {
-        if (
-          !excludedFilePatterns?.length ||
-          !excludedFilePatterns.some((pattern) => minimatch(file.filename, pattern))
-        ) {
-          result[prAuthor].simplificationReward = result[prAuthor].simplificationReward ?? {
-            files: [],
-            url: pull.html_url,
-          };
+        this._processFile(file, excludedFilePatterns, prAuthor, pull, result);
+      }
+    } catch (e) {
+      if (e && typeof e === "object" && "status" in e && e.status === 404) {
+        this.context.logger.warn("No file was found in the pull-request, skipping", {
+          url: pull.html_url,
+          owner: pull.base.repo.owner.login,
+          repo: pull.base.repo.name,
+          pull_number: pull.number,
+          err: e,
+        });
+        return result;
+      }
+      throw e;
+    }
+    return result;
+  }
 
-          const reward = Math.max((file.deletions - file.additions) / this._simplificationRate, 0);
-          if (reward !== 0) {
-            result[prAuthor].simplificationReward.files.push({
-              additions: file.additions,
-              deletions: file.deletions,
-              reward: reward,
-              fileName: file.filename,
-            });
-          }
-        }
+  private _processFile(
+    file: GitHubPullRequestFile,
+    excludedFilePatterns: string[] | undefined,
+    prAuthor: string,
+    pull: GitHubPullRequest,
+    result: Result
+  ) {
+    if (!excludedFilePatterns?.length || !excludedFilePatterns.some((pattern) => minimatch(file.filename, pattern))) {
+      result[prAuthor].simplificationReward = result[prAuthor].simplificationReward ?? {
+        files: [],
+        url: pull.html_url,
+      };
+      const reward = Math.max((file.deletions - file.additions) / this._simplificationRate, 0);
+      if (reward !== 0) {
+        result[prAuthor].simplificationReward.files.push({
+          additions: file.additions,
+          deletions: file.deletions,
+          reward: reward,
+          fileName: file.filename,
+        });
       }
     }
-
-    return result;
   }
 
   get enabled(): boolean {

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@ubiquity-os/text-conversation-rewards-ui",
   "scripts": {
-    "ui:dev": "bunx --bun vite",
-    "ui:build": "bunx --bun vite build",
-    "ui:build-watch": "bunx --bun vite build --watch",
-    "ui:preview": "bunx --bun vite preview"
+    "ui:dev": "bun x --bun vite",
+    "ui:build": "bun x --bun vite build",
+    "ui:build-watch": "bun x --bun vite build --watch",
+    "ui:preview": "bun x --bun vite preview"
   }
 }


### PR DESCRIPTION
Added some caps to yell more at the LLM about not adding backticks around the answer when all we are interested about is the JSON content itself. Also added a `replace` to make sure that even if the LLM ignores the instructions we manually remove them.

Also, fixed the simplification incentives that would often crash because no files could be found in the pull-request.

QA:
https://github.com/ubiquity-os-marketplace/daemon-pricing/issues/100#issuecomment-2840774032
https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/302#issuecomment-2840788617