### PR TITLE
fix: the location entry contains the hash in the URL

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -44,7 +44,8 @@
     "Numberish",
     "OPENROUTER",
     "keccak",
-    "UUSD"
+    "UUSD",
+    "issuecomment"
   ],
   "dictionaries": ["typescript", "node", "software-terms"],
   "import": [

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -3,12 +3,14 @@ import { ContextPlugin } from "../types/plugin-input";
 import { Super } from "./supabase/helpers/supabase";
 import { Wallet } from "./supabase/helpers/wallet";
 import { Database } from "./supabase/types/database";
+import { Location } from "../helpers/location";
 
 export function createAdapters(supabaseClient: SupabaseClient<Database>, context: ContextPlugin) {
   return {
     supabase: {
       wallet: new Wallet(supabaseClient, context),
       super: new Super(supabaseClient, context),
+      location: new Location(supabaseClient, context),
     },
   };
 }

--- a/src/helpers/location.ts
+++ b/src/helpers/location.ts
@@ -43,7 +43,7 @@ export class Location extends Super {
   }
 
   // Refer to https://github.com/ubiquity-os-marketplace/command-wallet/pull/51
-  public async getOrCreateIssueLocation(issue: { issueId: number; issueUrl: string; commentId?: number }) {
+  public async getOrCreateIssueLocation(issue: { issueId: number; issueUrl: string }) {
     let locationId: number | null = null;
 
     const { data: locationData } = await this.supabase

--- a/src/helpers/location.ts
+++ b/src/helpers/location.ts
@@ -1,0 +1,81 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "../adapters";
+import { ContextPlugin } from "../types/plugin-input";
+import { getRepo, parseGitHubUrl } from "../start";
+import { Super } from "../adapters/supabase/helpers/supabase";
+
+export class Location extends Super {
+  constructor(supabase: SupabaseClient<Database>, context: ContextPlugin) {
+    super(supabase, context);
+  }
+
+  public async upsert(locationData: Database["public"]["Tables"]["locations"]["Insert"]) {
+    const { repository_id, issue_id } = locationData;
+
+    const { data: existingData } = await this.supabase
+      .from("locations")
+      .select()
+      .match({ repository_id, issue_id })
+      .single();
+
+    if (existingData) {
+      const { data, error } = await this.supabase
+        .from("locations")
+        .update(locationData)
+        .match({ repository_id, issue_id })
+        .select()
+        .single();
+
+      if (error || !data) {
+        throw this.context.logger.error("Failed to update location", { err: error, locationData });
+      }
+
+      return data;
+    } else {
+      const { data, error } = await this.supabase.from("locations").insert(locationData).select().single();
+
+      if (error || !data) {
+        throw this.context.logger.error("Failed to insert location", { err: error, locationData });
+      }
+
+      return data;
+    }
+  }
+
+  // Refer to https://github.com/ubiquity-os-marketplace/command-wallet/pull/51
+  public async getOrCreateIssueLocation(issue: { issueId: number; issueUrl: string; commentId?: number }) {
+    let locationId: number | null = null;
+
+    const { data: locationData } = await this.supabase
+      .from("locations")
+      .select("id")
+      .eq("issue_id", issue.issueId)
+      .eq("node_url", issue.issueUrl)
+      .single();
+
+    if (!locationData) {
+      const issueItem = await getRepo(this.context, parseGitHubUrl(issue.issueUrl));
+      const { data: newLocationData, error } = await this.supabase
+        .from("locations")
+        .insert({
+          node_url: issue.issueUrl,
+          issue_id: issue.issueId,
+          node_type: "Issue",
+          repository_id: issueItem.id,
+        })
+        .select("id")
+        .single();
+      if (!newLocationData || error) {
+        this.context.logger.error("Failed to create a new location", error);
+      } else {
+        locationId = newLocationData.id;
+      }
+    } else {
+      locationId = locationData.id;
+    }
+    if (!locationId) {
+      throw this.context.logger.error("Failed to retrieve the related location from issue", { issue });
+    }
+    return locationId;
+  }
+}

--- a/src/parser/github-comment-module.ts
+++ b/src/parser/github-comment-module.ts
@@ -163,7 +163,7 @@ export class GithubCommentModule extends BaseModule {
           });
           if (comment) {
             await this.context.adapters.supabase.location.upsert({
-              issue_id: this.context.payload.issue.number,
+              issue_id: this.context.payload.issue.id,
               node_url: `${this.context.payload.issue.html_url}#issuecomment-${comment.id}`,
               repository_id: this.context.payload.repository.id,
               comment_id: comment.id,

--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -543,6 +543,7 @@ export class PaymentModule extends BaseModule {
     return result;
   }
 
+  // Refer to https://github.com/ubiquity-os-marketplace/command-wallet/pull/51
   async _getOrCreateIssueLocation(issue: { issueId: number; issueUrl: string }) {
     let locationId: number | null = null;
 


### PR DESCRIPTION
Resolves #333

Since the `payment` module is not aware of the github comment (it is not created yet) I added a step where the github comment upserts the location to add the anchor of the url. This way if we disable the GitHub comment the url will still be in the db, without the anchor (because there never was a comment in the first place).
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
