### PR TITLE
fix: change RPC generation

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -11,6 +11,17 @@ jobs:
     permissions: write-all
 
     steps:
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate RPCs
+        run: bun run fetch-rpcs
+
       - uses: ubiquity-os/action-deploy-plugin@main
         with:
           treatAsEsm: true

--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -11,17 +11,6 @@ jobs:
     permissions: write-all
 
     steps:
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Generate RPCs
-        run: bun run fetch-rpcs
-
       - uses: ubiquity-os/action-deploy-plugin@main
         with:
           treatAsEsm: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage
 test-dashboard.md
 *.private.env.json
 output.html
+src/types/rpcs.json

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 bun commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 bun lint-staged

--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
         "eslint-plugin-check-file": "^2.8.0",
         "eslint-plugin-sonarjs": "3.0.2",
         "hono": "^4.6.10",
-        "husky": "8.0.3",
+        "husky": "^9.1.7",
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
         "jest-md-dashboard": "0.8.0",
@@ -1340,7 +1340,7 @@
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
-    "husky": ["husky@8.0.3", "", { "bin": { "husky": "lib/bin.js" } }, "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg=="],
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
         "@ubiquity-os/plugin-sdk": "3.1.3",
         "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
         "decimal.js": "10.4.3",
-        "eth-chains": "^2.0.0",
         "ethers": "^5.7.2",
         "js-tiktoken": "^1.0.19",
         "jsdom": "24.0.0",
@@ -1165,8 +1164,6 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
-
-    "eth-chains": ["eth-chains@2.0.0", "", {}, "sha512-TSfA9sYwEenQF+8/+T9DAnhCGB3yy7/Rl9J2QpibD9Bax8Btu3uTOW5mGIp7kh4gYyeozDxK7zHKBiB5upWU1w=="],
 
     "ethers": ["ethers@5.8.0", "", { "dependencies": { "@ethersproject/abi": "5.8.0", "@ethersproject/abstract-provider": "5.8.0", "@ethersproject/abstract-signer": "5.8.0", "@ethersproject/address": "5.8.0", "@ethersproject/base64": "5.8.0", "@ethersproject/basex": "5.8.0", "@ethersproject/bignumber": "5.8.0", "@ethersproject/bytes": "5.8.0", "@ethersproject/constants": "5.8.0", "@ethersproject/contracts": "5.8.0", "@ethersproject/hash": "5.8.0", "@ethersproject/hdnode": "5.8.0", "@ethersproject/json-wallets": "5.8.0", "@ethersproject/keccak256": "5.8.0", "@ethersproject/logger": "5.8.0", "@ethersproject/networks": "5.8.0", "@ethersproject/pbkdf2": "5.8.0", "@ethersproject/properties": "5.8.0", "@ethersproject/providers": "5.8.0", "@ethersproject/random": "5.8.0", "@ethersproject/rlp": "5.8.0", "@ethersproject/sha2": "5.8.0", "@ethersproject/signing-key": "5.8.0", "@ethersproject/solidity": "5.8.0", "@ethersproject/strings": "5.8.0", "@ethersproject/transactions": "5.8.0", "@ethersproject/units": "5.8.0", "@ethersproject/wallet": "5.8.0", "@ethersproject/web": "5.8.0", "@ethersproject/wordlists": "5.8.0" } }, "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format:prettier": "prettier --write .",
     "format:cspell": "cspell **/*",
     "knip": "knip",
-    "prepare": "husky install",
+    "prepare": "husky",
     "dev": "bun --watch src/index.ts",
     "server": "bun --watch --no-clear-screen src/web/api/index.ts"
   },
@@ -72,7 +72,7 @@
     "eslint-plugin-check-file": "^2.8.0",
     "eslint-plugin-sonarjs": "3.0.2",
     "hono": "^4.6.10",
-    "husky": "8.0.3",
+    "husky": "^9.1.7",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
     "jest-md-dashboard": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format:prettier": "prettier --write .",
     "format:cspell": "cspell **/*",
     "knip": "knip",
-    "prepare": "husky",
+    "prepare": "husky && bun run fetch-rpcs",
     "dev": "bun --watch src/index.ts",
     "server": "bun --watch --no-clear-screen src/web/api/index.ts",
     "fetch-rpcs": "mkdir -p src/types && bun -e \"await Bun.write('src/types/rpcs.json', await (await fetch('https://chainlist.org/rpcs.json')).text())\""

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "knip": "knip",
     "prepare": "husky",
     "dev": "bun --watch src/index.ts",
-    "server": "bun --watch --no-clear-screen src/web/api/index.ts"
+    "server": "bun --watch --no-clear-screen src/web/api/index.ts",
+    "fetch-rpcs": "mkdir -p src/types && bun -e \"await Bun.write('src/types/rpcs.json', await (await fetch('https://chainlist.org/rpcs.json')).text())\""
   },
   "keywords": [
     "typescript",
@@ -38,7 +39,6 @@
     "@ubiquity-os/plugin-sdk": "3.1.3",
     "@ubiquity-os/ubiquity-os-logger": "^1.4.0",
     "decimal.js": "10.4.3",
-    "eth-chains": "^2.0.0",
     "ethers": "^5.7.2",
     "js-tiktoken": "^1.0.19",
     "jsdom": "24.0.0",

--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -35,7 +35,7 @@ import { IssueActivity } from "../issue-activity";
 import { getRepo, parseGitHubUrl } from "../start";
 import { BaseModule } from "../types/module";
 import { PayoutMode, Result } from "../types/results";
-import ethChains from "eth-chains";
+import chains from "../types/rpcs.json";
 
 interface Payload {
   evmNetworkId: number;
@@ -250,7 +250,7 @@ export class PaymentModule extends BaseModule {
   }
 
   _getNetworkExplorer(networkId: number): string {
-    const chain = ethChains.chains.get(networkId);
+    const chain = chains.find((chain) => chain.chainId === networkId);
     return chain?.explorers?.[0].url || "https://blockscan.com";
   }
 


### PR DESCRIPTION
Resolves #339

Instead of using an NPM package that would eventually get deprecated and does not compile on ESM environments, let's directly get the json file and store it locally during the build.
Husky changes are unrelated but I was tired of the warning on each commit.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
