### PR TITLE
fix: use three-dot comparison in getTripleDotDiffAsObject

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -48,7 +48,8 @@
     "issuecomment",
     "qwen",
     "deepseek",
-    "summarise"
+    "summarise",
+    "basehead"
   ],
   "dictionaries": ["typescript", "node", "software-terms"],
   "import": [

--- a/src/parser/review-incentivizer-module.ts
+++ b/src/parser/review-incentivizer-module.ts
@@ -68,11 +68,11 @@ export class ReviewIncentivizerModule extends BaseModule {
   }
 
   async getTripleDotDiffAsObject(owner: string, repo: string, baseSha: string, headSha: string): Promise<CommitDiff> {
-    const response = await this.context.octokit.rest.repos.compareCommits({
+    // Use three-dot comparison to exclude changes from the base branch
+    const response = await this.context.octokit.rest.repos.compareCommitsWithBasehead({
       owner,
       repo,
-      base: baseSha,
-      head: headSha,
+      basehead: `${baseSha}...${headSha}`,
     });
 
     const files = response.data.files || [];

--- a/tests/review-incentivizer.test.ts
+++ b/tests/review-incentivizer.test.ts
@@ -137,7 +137,7 @@ describe("Review Incentivizer", () => {
   });
 
   it("Should skip removed files in review incentives diff calculation", async () => {
-    jest.spyOn(ctx.octokit.rest.repos, "compareCommits").mockImplementationOnce(async () => {
+    jest.spyOn(ctx.octokit.rest.repos, "compareCommitsWithBasehead").mockImplementationOnce(async () => {
       return {
         data: {
           files: [
@@ -161,7 +161,7 @@ describe("Review Incentivizer", () => {
             },
           ],
         },
-      } as unknown as RestEndpointMethodTypes["repos"]["compareCommits"]["response"];
+      } as unknown as RestEndpointMethodTypes["repos"]["compareCommitsWithBasehead"]["response"];
     });
 
     const { ReviewIncentivizerModule } = await import("../src/parser/review-incentivizer-module");


### PR DESCRIPTION
## Summary

This PR fixes the core issue by correcting a single line - the method `getTripleDotDiffAsObject` was using the wrong GitHub API.

## The Bug

The method `getTripleDotDiffAsObject` was incorrectly using `compareCommits` which performs a TWO-dot diff (`base..head`), showing all changes between two commits including those from merged branches.

## The Fix  

Changed to use `compareCommitsWithBasehead` with `base...head` syntax, which performs a THREE-dot diff that excludes changes from the base branch - exactly what the method name suggests it should do.

## Why This Works

GitHub's three-dot comparison (`base...head`) shows only the changes introduced by the feature branch, automatically excluding any changes that came from the base branch through merges. This is the standard way GitHub displays PR diffs.

## Comparison to Other Approaches

- #420 attempts to fix this by manually filtering merge commits and building a file list
- #424 (my previous PR) removes complexity but still changes more than necessary
- This PR is the minimal fix - just one line change to use the correct API

## Testing

- Updated test to mock the correct API method
- Added "basehead" to cspell dictionary

Resolves #419

cc @gentlementlegen @whilefoo @0x4007
