### PR TITLE
fix: enforce structured outputs for relevance scoring

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -542,14 +542,32 @@ export class ContentEvaluatorModule extends BaseModule {
 
   async _submitPrompt(prompt: string, maxTokens: number): Promise<Relevances> {
     try {
-      const res = await callLlm(
-        {
-          response_format: { type: "json_object" },
-          messages: [{ role: "system", content: prompt }],
-          reasoning_effort: this._configuration?.openAi.reasoningEffort,
+      const payload = {
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "comment_relevance_scores",
+            strict: true,
+            schema: openAiRelevanceResponseSchema,
+          },
         },
-        this.context
-      );
+        messages: [{ role: "system", content: prompt }],
+        reasoning_effort: this._configuration?.openAi.reasoningEffort,
+      } as const;
+
+      let res: Awaited<ReturnType<typeof callLlm>>;
+      try {
+        res = await callLlm(payload, this.context);
+      } catch (error) {
+        // Fallback for providers that only support json_object.
+        res = await callLlm(
+          {
+            ...payload,
+            response_format: { type: "json_object" },
+          },
+          this.context
+        );
+      }
 
       if (isAsyncIterable(res)) {
         throw this.context.logger.error("Unexpected streaming response from the LLM");


### PR DESCRIPTION
## Summary
- switch content evaluator LLM call to `response_format: json_schema` with strict schema for comment relevance output
- keep backward compatibility by falling back to `json_object` when provider does not support structured output
- keep existing JSON parsing/validation path unchanged

## Validation
- Unable to run local checks: this environment does not have `bun` installed, and project dependencies are not installed for `tsc` in workspace.

Closes #369
