### PR TITLE
fix: tighten collaborative checks for reward generation

### DIFF
--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -2,6 +2,14 @@ import { GitHubPullRequest } from "../github-types";
 import { IssueActivity } from "../issue-activity";
 import { ContextPlugin } from "../types/plugin-input";
 
+/**
+ * Determines whether an issue closure includes collaboration from another human contributor.
+ *
+ * A task is collaborative when either:
+ * - the closer differs from the issue creator, or
+ * - a different human changed pricing labels, or
+ * - a non-assignee human approved a linked merged pull request.
+ */
 export function isCollaborative(data: Readonly<IssueActivity>) {
   if (!data.self?.closed_by || !data.self.user) return false;
   const issueCreator = data.self.user;
@@ -12,14 +20,18 @@ export function isCollaborative(data: Readonly<IssueActivity>) {
         event.event === "labeled" &&
         "label" in event &&
         (event.label.name.startsWith("Time: ") || event.label.name.startsWith("Priority: ")) &&
-        event.actor.id !== issueCreator.id &&
-        event.actor.type === "User"
+        event.actor?.id !== issueCreator.id &&
+        event.actor?.type === "User"
     );
     return !!pricingEventsByDifferentHuman || nonAssigneeApprovedReviews(data);
   }
   return true;
 }
 
+/**
+ * Returns whether any linked merged pull request has an approval from a non-assignee human.
+ * Requested reviewers are ignored to avoid counting self-requests as collaboration.
+ */
 export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {
   if (!data.linkedMergedPullRequests[0]) {
     return false;

--- a/tests/helpers/checkers.test.ts
+++ b/tests/helpers/checkers.test.ts
@@ -59,6 +59,20 @@ describe("isCollaborative", () => {
     expect(isCollaborative(activity)).toBe(true);
   });
 
+  it("returns false when pricing label actor is missing", () => {
+    const activity = buildActivity({
+      events: [
+        {
+          event: "labeled",
+          label: { name: "Priority: 2 (Medium)" },
+          actor: null,
+        },
+      ],
+    });
+
+    expect(isCollaborative(activity)).toBe(false);
+  });
+
   it("does not treat empty non-assignee review matches as collaborative", () => {
     const activity = buildActivity({
       linkedMergedPullRequests: [
@@ -95,6 +109,33 @@ describe("isCollaborative", () => {
 
     expect(nonAssigneeApprovedReviews(activity)).toBe(true);
     expect(isCollaborative(activity)).toBe(true);
+  });
+
+  it("returns false when approval exists only on the second linked merged pull", () => {
+    const activity = buildActivity({
+      linkedMergedPullRequests: [
+        {
+          self: { requested_reviewers: [] },
+          reviews: [
+            {
+              state: "COMMENTED",
+              user: { id: 2, type: "User" },
+            },
+          ],
+        },
+        {
+          self: { requested_reviewers: [] },
+          reviews: [
+            {
+              state: "APPROVED",
+              user: { id: 3, type: "User" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(nonAssigneeApprovedReviews(activity)).toBe(false);
   });
 
   it("returns true when closer is not issue creator", () => {


### PR DESCRIPTION
## Summary
- fix `isCollaborative` so bot-applied Time/Priority labels no longer count as human collaboration
- fix `nonAssigneeApprovedReviews` to return a boolean (preventing empty-array truthiness from falsely allowing rewards)
- consider all assignee IDs and only count approved reviews by non-assignee human users
- add focused tests for collaboration gating edge-cases

## Validation
- `npx jest tests/helpers/checkers.test.ts --setupFiles dotenv/config`
- `npx jest tests/payment-generatable.test.ts --setupFiles dotenv/config`

Closes #455
