### PR TITLE
fix(ci): run compute workflow from local action on artifact refs

### DIFF
--- a/.github/workflows/compute.yml
+++ b/.github/workflows/compute.yml
@@ -53,8 +53,5 @@ jobs:
       # However, this would mean that we would be unable to call it from the branch specified in ubiquity-os-config
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
       - name: Run compute rewards
-        run: bun run src/index.ts
+        uses: ./


### PR DESCRIPTION
## Summary
- update `compute.yml` to invoke the local action (`uses: ./`) instead of running `bun install` and `bun run src/index.ts`
- align compute execution with artifact branches where only `dist/**` is published

## Why
On `dist/*` branches, source files are intentionally absent. Running `bun run src/index.ts` fails there even when lock/package files are present.

Closes https://github.com/ubiquity-os/ubiquity-os-kernel/issues/320
