### PR TITLE
chore(ci): consolidate deploy workflows

### DIFF
--- a/.github/workflows/update-configuration.yml
+++ b/.github/workflows/update-configuration.yml
@@ -96,7 +96,7 @@ jobs:
           action: ${{ github.event_name == 'delete' && 'delete' || 'publish' }}
           treatAsEsm: true
           sourcemap: true
-          pluginEntry: "${{ github.workspace }}/src/action.ts"
+          pluginEntry: "${{ github.workspace }}/src/index.ts"
           excludeSupportedEvents: ${{ env.EXCLUDE_SUPPORTED_EVENTS }}
           skipBotEvents: ${{ env.SKIP_BOT_EVENTS }}
         env:


### PR DESCRIPTION
## Summary
- consolidate deployment into .github/workflows/update-configuration.yml (Action + optional Deno)
- remove legacy standalone deploy workflows (deno-deploy.yml / worker-deploy.yml / worker-delete.yml when present)
- keep plugin-specific manifest defaults

## Defaults in this repo
- deploy_deno_enabled: false
- skip_bot_events: false
- exclude_supported_events: issue_comment.created
