### PR TITLE
feat: add task adapter abstraction for github decoupling

### DIFF
--- a/src/adapters/asana/adapter.ts
+++ b/src/adapters/asana/adapter.ts
@@ -1,0 +1,244 @@
+import { Task, TaskAdapter, TaskComment, TaskEvent, LinkedPullRequest } from "../types/task-adapter";
+
+/**
+ * Asana API adapter for task management decoupling
+ *
+ * This adapter allows the plugin to work with Asana instead of GitHub,
+ * enabling the reward system to work across different task management platforms.
+ */
+export class AsanaAdapter implements TaskAdapter {
+  platform = "asana";
+  private _accessToken: string;
+  private _workspaceGid: string;
+  private _projectGid?: string;
+
+  constructor(config: { accessToken: string; workspaceGid: string; projectGid?: string }) {
+    this._accessToken = config.accessToken;
+    this._workspaceGid = config.workspaceGid;
+    this._projectGid = config.projectGid;
+  }
+
+  private async _asanaRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    const response = await fetch(`https://app.asana.com/api/1.0${endpoint}`, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${this._accessToken}`,
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Asana API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as { data: T };
+    return data.data;
+  }
+
+  async getTask(taskRef: string): Promise<Task> {
+    // taskRef can be either a task GID or a full Asana URL
+    const taskGid = this._extractAsanaGid(taskRef);
+
+    const task = await this._asanaRequest<{
+      gid: string;
+      name: string;
+      notes: string;
+      completed: boolean;
+      assignee?: { gid: string; name: string };
+      memberships: Array<{ section?: { gid: string; name: string }; project?: { gid: string; name: string } }>;
+      created_at: string;
+      modified_at: string;
+      permalink_url: string;
+      custom_fields?: Array<{ gid: string; name: string; display_value: string }>;
+    }>(
+      `/tasks/${taskGid}?opt_fields=name,notes,completed,assignee,memberships,created_at,modified_at,permalink_url,custom_fields`
+    );
+
+    // Get project info from memberships (for potential future use)
+    // const projectMembership = task.memberships?.find((m) => m.project);
+    // const projectName = projectMembership?.project?.name ?? "Unknown Project";
+
+    return {
+      id: task.gid,
+      number: undefined, // Asana doesn't have issue numbers like GitHub
+      title: task.name,
+      body: task.notes,
+      state: task.completed ? "completed" : "open",
+      assignees: task.assignee ? [{ id: task.assignee.gid, name: task.assignee.name }] : [],
+      user: { id: "system", name: "System" }, // Asana doesn't have a single "creator" context
+      html_url: task.permalink_url,
+      created_at: task.created_at,
+      updated_at: task.modified_at,
+    };
+  }
+
+  async getComments(taskRef: string): Promise<TaskComment[]> {
+    const taskGid = this._extractAsanaGid(taskRef);
+
+    const stories = await this._asanaRequest<
+      Array<{
+        gid: string;
+        created_at: string;
+        created_by: { gid: string; name: string };
+        type: string;
+        text?: string;
+        subtype?: string;
+      }>
+    >(`/tasks/${taskGid}/stories?opt_fields=gid,created_at,created_by,type,text,subtype&limit=100`);
+
+    // Filter to only actual comments (stories with text content)
+    return stories
+      .filter((s) => s.type === "comment" && s.text)
+      .map((s) => ({
+        id: s.gid,
+        body: s.text ?? "",
+        user: {
+          id: s.created_by.gid,
+          name: s.created_by.name,
+        },
+        created_at: s.created_at,
+        updated_at: s.created_at,
+        html_url: `https://app.asana.com/0/0/${s.gid}`, // Asana stories don't have permalinks
+      }));
+  }
+
+  async getEvents(taskRef: string): Promise<TaskEvent[]> {
+    const taskGid = this._extractAsanaGid(taskRef);
+
+    const stories = await this._asanaRequest<
+      Array<{
+        gid: string;
+        created_at: string;
+        created_by: { gid: string; name: string };
+        type: string;
+        action: string;
+        resource_subtype?: string;
+      }>
+    >(`/tasks/${taskGid}/stories?opt_fields=gid,created_at,created_by,type,action,resource_subtype&limit=100`);
+
+    return stories.map((s) => ({
+      id: s.gid,
+      event: `${s.action}:${s.resource_subtype ?? s.type}`,
+      created_at: s.created_at,
+      actor: {
+        id: s.created_by.gid,
+        name: s.created_by.name,
+      },
+    }));
+  }
+
+  async getLinkedPullRequests(_taskRef: string): Promise<LinkedPullRequest[]> {
+    // Asana doesn't have native pull request linking
+    // Could implement custom field-based linking if needed
+    return [];
+  }
+
+  async postComment(taskRef: string, body: string): Promise<TaskComment> {
+    const taskGid = this._extractAsanaGid(taskRef);
+
+    const story = await this._asanaRequest<{
+      gid: string;
+      created_at: string;
+      created_by: { gid: string; name: string };
+      text: string;
+    }>(`/tasks/${taskGid}/stories`, {
+      method: "POST",
+      body: JSON.stringify({
+        data: {
+          type: "comment",
+          text: body,
+        },
+      }),
+    });
+
+    return {
+      id: story.gid,
+      body: story.text,
+      user: {
+        id: story.created_by.gid,
+        name: story.created_by.name,
+      },
+      created_at: story.created_at,
+      updated_at: story.created_at,
+    };
+  }
+
+  async updateTask(taskRef: string, updates: Partial<Task>): Promise<Task> {
+    const taskGid = this._extractAsanaGid(taskRef);
+
+    const updateData: Record<string, unknown> = {};
+    if (updates.title) updateData.name = updates.title;
+    if (updates.body !== undefined) updateData.notes = updates.body;
+    if (updates.state === "completed") updateData.completed = true;
+    else if (updates.state === "open") updateData.completed = false;
+
+    await this._asanaRequest(`/tasks/${taskGid}`, {
+      method: "PUT",
+      body: JSON.stringify({ data: updateData }),
+    });
+
+    return this.getTask(taskRef);
+  }
+
+  async hasPermission(_taskRef: string, _userId: string | number, _permission: string): Promise<boolean> {
+    // Asana permission checking would need to be implemented based on workspace/project permissions
+    return true;
+  }
+
+  /**
+   * Extract Asana GID from URL or return as-is if already a GID
+   */
+  private _extractAsanaGid(ref: string): string {
+    // If it's a URL, extract the GID from the path
+    if (ref.includes("app.asana.com")) {
+      const match = ref.match(/\/(\d+)(?:\?|$)/);
+      if (match) return match[1];
+    }
+    // Assume it's already a GID
+    return ref;
+  }
+
+  /**
+   * Create a new task in Asana
+   */
+  static async createTask(
+    config: { accessToken: string; workspaceGid: string; projectGid?: string },
+    params: { name: string; notes?: string; completed?: boolean; assignee?: string }
+  ): Promise<Task> {
+    const adapter = new AsanaAdapter(config);
+
+    const task = await adapter._asanaRequest<{
+      gid: string;
+      name: string;
+      notes: string;
+      completed: boolean;
+      created_at: string;
+      modified_at: string;
+      permalink_url: string;
+    }>("/tasks", {
+      method: "POST",
+      body: JSON.stringify({
+        data: {
+          name: params.name,
+          notes: params.notes,
+          completed: params.completed ?? false,
+          ...(params.assignee ? { assignee: params.assignee } : {}),
+          ...(config.projectGid ? { projects: [config.projectGid] } : {}),
+        },
+      }),
+    });
+
+    return {
+      id: task.gid,
+      title: task.name,
+      body: task.notes,
+      state: task.completed ? "completed" : "open",
+      assignees: [],
+      user: { id: "system", name: "System" },
+      html_url: task.permalink_url,
+      created_at: task.created_at,
+      updated_at: task.modified_at,
+    };
+  }
+}

--- a/src/adapters/github/adapter.ts
+++ b/src/adapters/github/adapter.ts
@@ -1,0 +1,161 @@
+import { ContextPlugin } from "../../types/plugin-input";
+import { Task, TaskAdapter, TaskComment, TaskEvent, LinkedPullRequest } from "../types/task-adapter";
+import { parseGitHubUrl, getIssue, getIssueComments, getIssueEvents } from "../../start";
+import { collectLinkedPulls } from "../../data-collection/collect-linked-pulls";
+
+export class GitHubAdapter implements TaskAdapter {
+  platform = "github";
+  private _context: ContextPlugin;
+
+  constructor(context: ContextPlugin) {
+    this._context = context;
+  }
+
+  async getTask(taskRef: string): Promise<Task> {
+    const params = parseGitHubUrl(taskRef);
+    const issue = await getIssue(this._context, params);
+
+    // Handle labels - they can be various formats in GitHub API
+    const labels =
+      issue.labels?.map((label) => {
+        if (typeof label === "string") {
+          return { id: label, name: label, color: undefined };
+        }
+        return {
+          id: (label as { id?: number | string }).id ?? label,
+          name: (label as { name?: string }).name ?? "",
+          color: (label as { color?: string }).color,
+        };
+      }) ?? [];
+
+    return {
+      id: issue.id,
+      number: issue.number,
+      title: issue.title,
+      body: issue.body ?? null,
+      state: issue.state,
+      state_reason: issue.state_reason ?? undefined,
+      assignees: (issue.assignees ?? []).map((a) => ({
+        id: a.id,
+        login: a.login,
+        name: (a as { name?: string }).name ?? undefined,
+      })),
+      labels: labels as Array<{ id: string | number; name: string; color?: string }>,
+      user: {
+        id: issue.user?.id ?? 0,
+        login: issue.user?.login,
+        name: (issue.user as { name?: string })?.name ?? undefined,
+      },
+      html_url: issue.html_url,
+      created_at: issue.created_at,
+      updated_at: issue.updated_at,
+      pull_request: issue.pull_request
+        ? {
+            url: issue.pull_request.url ?? "",
+            html_url: issue.pull_request.html_url ?? "",
+          }
+        : undefined,
+    };
+  }
+
+  async getComments(taskRef: string): Promise<TaskComment[]> {
+    const params = parseGitHubUrl(taskRef);
+    const comments = await getIssueComments(this._context, params);
+
+    return comments.map((c) => ({
+      id: c.id,
+      body: c.body ?? "",
+      user: {
+        id: c.user?.id ?? 0,
+        login: c.user?.login,
+      },
+      created_at: c.created_at,
+      updated_at: c.updated_at,
+      html_url: c.html_url,
+    }));
+  }
+
+  async getEvents(taskRef: string): Promise<TaskEvent[]> {
+    const params = parseGitHubUrl(taskRef);
+    const events = await getIssueEvents(this._context, params);
+
+    return events.map((e) => ({
+      id: e.id,
+      event: e.event,
+      created_at: e.created_at,
+      actor: e.actor
+        ? {
+            id: e.actor.id,
+            login: e.actor.login,
+          }
+        : undefined,
+    }));
+  }
+
+  async getLinkedPullRequests(taskRef: string): Promise<LinkedPullRequest[]> {
+    const params = parseGitHubUrl(taskRef);
+    const linkedPulls = await collectLinkedPulls(this._context, params);
+
+    return linkedPulls.map((pull) => ({
+      url: pull.url ?? "",
+      html_url: pull.url ?? "",
+      number: pull.number ?? 0,
+      title: pull.title ?? "",
+      state: pull.state ?? "",
+      merged: (pull as unknown as { merged?: boolean }).merged ?? false,
+      author: {
+        id: pull.author?.id ?? 0,
+        login: pull.author?.login,
+      },
+    }));
+  }
+
+  async postComment(taskRef: string, body: string): Promise<TaskComment> {
+    const params = parseGitHubUrl(taskRef);
+    const { octokit } = this._context;
+
+    const { data } = await octokit.rest.issues.createComment({
+      owner: params.owner,
+      repo: params.repo,
+      issue_number: params.issue_number,
+      body,
+    });
+
+    return {
+      id: data.id,
+      body: data.body ?? "",
+      user: {
+        id: data.user?.id ?? 0,
+        login: data.user?.login,
+      },
+      created_at: data.created_at,
+      updated_at: data.updated_at,
+      html_url: data.html_url,
+    };
+  }
+
+  async updateTask(taskRef: string, updates: Partial<Task>): Promise<Task> {
+    const params = parseGitHubUrl(taskRef);
+    const { octokit } = this._context;
+
+    const updatePayload: Record<string, unknown> = {};
+    if (updates.state) {
+      updatePayload.state = updates.state === "closed" ? "closed" : "open";
+    }
+
+    await octokit.rest.issues.update({
+      owner: params.owner,
+      repo: params.repo,
+      issue_number: params.issue_number,
+      ...updatePayload,
+    });
+
+    return this.getTask(taskRef);
+  }
+
+  async hasPermission(_taskRef: string, _userId: string | number, _permission: string): Promise<boolean> {
+    // For GitHub, permission checks would need to be implemented based on the specific permission
+    // This is a placeholder implementation
+    return true;
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -4,6 +4,14 @@ import { Super } from "./supabase/helpers/supabase";
 import { Wallet } from "./supabase/helpers/wallet";
 import { Database } from "./supabase/types/database";
 import { Location } from "../helpers/location";
+import { TaskAdapter, TaskAdapterConstructor } from "./types/task-adapter";
+import { GitHubAdapter } from "./github/adapter";
+import { AsanaAdapter } from "./asana/adapter";
+
+export * from "./supabase/types/database";
+export * from "./types/task-adapter";
+export { GitHubAdapter } from "./github/adapter";
+export { AsanaAdapter } from "./asana/adapter";
 
 export function createAdapters(supabaseClient: SupabaseClient<Database>, context: ContextPlugin) {
   return {
@@ -15,4 +23,38 @@ export function createAdapters(supabaseClient: SupabaseClient<Database>, context
   };
 }
 
-export * from "./supabase/types/database";
+/**
+ * Factory function to create the appropriate task adapter based on configuration
+ */
+export function createTaskAdapter(
+  context: ContextPlugin,
+  config: {
+    platform: "github" | "asana" | string;
+    asanaAccessToken?: string;
+    asanaWorkspaceGid?: string;
+    asanaProjectGid?: string;
+  }
+): TaskAdapter {
+  switch (config.platform) {
+    case "asana":
+      if (!config.asanaAccessToken) {
+        throw new Error("Asana access token is required for Asana adapter");
+      }
+      return new AsanaAdapter({
+        accessToken: config.asanaAccessToken,
+        workspaceGid: config.asanaWorkspaceGid ?? "",
+        projectGid: config.asanaProjectGid,
+      });
+    case "github":
+    default:
+      return new GitHubAdapter(context);
+  }
+}
+
+/**
+ * Registry of available task adapters
+ */
+export const taskAdapterRegistry: Record<string, TaskAdapterConstructor> = {
+  github: GitHubAdapter as unknown as TaskAdapterConstructor,
+  asana: AsanaAdapter as unknown as TaskAdapterConstructor,
+};

--- a/src/adapters/types/task-adapter.ts
+++ b/src/adapters/types/task-adapter.ts
@@ -1,0 +1,121 @@
+/**
+ * Abstract interface for task management systems (GitHub, Asana, Linear, etc.)
+ * This allows the plugin to be decoupled from any specific platform.
+ */
+
+export interface TaskComment {
+  id: string | number;
+  body: string;
+  user: {
+    id: string | number;
+    login?: string; // GitHub-specific
+    name?: string;
+  };
+  created_at: string;
+  updated_at?: string;
+  html_url?: string;
+}
+
+export interface TaskEvent {
+  id: string | number;
+  event: string;
+  created_at: string;
+  actor?: {
+    id: string | number;
+    login?: string;
+    name?: string;
+  };
+}
+
+export interface TaskAssignee {
+  id: string | number;
+  login?: string; // GitHub-specific
+  name?: string;
+  email?: string;
+}
+
+export interface Task {
+  id: string | number;
+  number?: number; // GitHub-specific (issue number)
+  title: string;
+  body: string | null;
+  state: "open" | "closed" | "completed" | "in_progress" | string;
+  state_reason?: string;
+  assignees: TaskAssignee[];
+  labels?: Array<{ id: string | number; name: string; color?: string }>;
+  user: {
+    id: string | number;
+    login?: string;
+    name?: string;
+  };
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  pull_request?: {
+    url: string;
+    html_url: string;
+  };
+}
+
+export interface LinkedPullRequest {
+  url: string;
+  html_url: string;
+  number: number;
+  title: string;
+  state: string;
+  merged: boolean;
+  author: {
+    id: string | number;
+    login?: string;
+    name?: string;
+  };
+}
+
+export interface TaskAdapter {
+  /**
+   * Get the platform name
+   */
+  platform: string;
+
+  /**
+   * Get a task by its URL or identifier
+   */
+  getTask(taskRef: string): Promise<Task>;
+
+  /**
+   * Get comments on a task
+   */
+  getComments(taskRef: string): Promise<TaskComment[]>;
+
+  /**
+   * Get events/activity on a task
+   */
+  getEvents(taskRef: string): Promise<TaskEvent[]>;
+
+  /**
+   * Get linked pull requests (GitHub-specific, may return empty for other platforms)
+   */
+  getLinkedPullRequests?(taskRef: string): Promise<LinkedPullRequest[]>;
+
+  /**
+   * Get a single comment
+   */
+  getComment?(taskRef: string, commentId: string | number): Promise<TaskComment>;
+
+  /**
+   * Post a comment to a task
+   */
+  postComment?(taskRef: string, body: string): Promise<TaskComment>;
+
+  /**
+   * Update task state
+   */
+  updateTask?(taskRef: string, updates: Partial<Task>): Promise<Task>;
+
+  /**
+   * Check if a user has specific permissions
+   */
+  hasPermission?(taskRef: string, userId: string | number, permission: string): Promise<boolean>;
+}
+
+export type TaskAdapterConstructor = new (context: unknown) => TaskAdapter;

--- a/src/configuration/task-adapter-config.ts
+++ b/src/configuration/task-adapter-config.ts
@@ -1,0 +1,62 @@
+import { StaticDecode, Type as T } from "@sinclair/typebox";
+
+/**
+ * Configuration for task management platform adapter
+ * Allows switching between GitHub, Asana, and other task management systems
+ */
+export const taskAdapterConfigurationType = T.Object(
+  {
+    /**
+     * The task management platform to use
+     * @default "github"
+     */
+    platform: T.Union([T.Literal("github"), T.Literal("asana"), T.String()], {
+      default: "github",
+      description: "The task management platform (github, asana, or custom)",
+    }),
+
+    /**
+     * Asana-specific configuration
+     * Only required when platform is set to "asana"
+     */
+    asana: T.Optional(
+      T.Object(
+        {
+          accessToken: T.String({
+            description: "Asana personal access token",
+          }),
+          workspaceGid: T.String({
+            description: "Asana workspace GID",
+          }),
+          projectGid: T.Optional(
+            T.String({
+              description: "Asana project GID (optional, for project-scoped operations)",
+            })
+          ),
+        },
+        { additionalProperties: false }
+      )
+    ),
+
+    /**
+     * Custom adapter configuration
+     * Used when platform is set to a custom adapter name
+     */
+    customAdapter: T.Optional(
+      T.Object(
+        {
+          adapterName: T.String({
+            description: "Name of the custom adapter to use",
+          }),
+          config: T.Record(T.String(), T.String(), {
+            description: "Key-value configuration for the custom adapter",
+          }),
+        },
+        { additionalProperties: false }
+      )
+    ),
+  },
+  { additionalProperties: false, default: { platform: "github" } }
+);
+
+export type TaskAdapterConfiguration = StaticDecode<typeof taskAdapterConfigurationType>;


### PR DESCRIPTION
## Summary

This PR implements the GitHub Decoupling feature by adding a task adapter abstraction layer.

### Changes

1. Task Adapter Interface - abstract interface for task management systems
2. GitHub Adapter - implements TaskAdapter using existing GitHub API
3. Asana Adapter - implements TaskAdapter for Asana integration
4. Task Adapter Configuration - type-safe config schema
5. Adapter Factory - createTaskAdapter function

### Motivation

Enables the plugin to work with any task management platform, not just GitHub.

### References

- ubiquity-os-marketplace/text-conversation-rewards#385
- devpool-directory/devpool-directory#5019