### PR TITLE
fix: Implement Differential Reward Distribution for Reopened Issues

### DIFF
--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -115,6 +115,8 @@ export class PaymentModule extends BaseModule {
 
     const payoutMode = await this._getPayoutMode(data);
     if (payoutMode === null) {
+      const hasDifferential = await this._handleDifferentialRewards(data, result, tokenGroups);
+      if (hasDifferential) return result;
       throw this.context.logger.warn("Rewards can not be transferred twice.");
     }
 
@@ -125,6 +127,29 @@ export class PaymentModule extends BaseModule {
     }
 
     return result;
+  }
+
+  private async _handleDifferentialRewards(
+    data: Readonly<IssueActivity>,
+    result: Result,
+    tokenGroups: { config: RewardSettings; usernames: string[] }[]
+  ): Promise<boolean> {
+    const previousRewards = this._extractPreviousRewards(data);
+    if (!Object.keys(previousRewards).length) return false;
+    this.context.logger.info("Previous rewards detected, computing differential for reopened issue.", {
+      previousRewards,
+    });
+    for (const group of tokenGroups) {
+      const groupResult = this._selectResultSubset(result, group.usernames);
+      const differential = this._computeDifferential(groupResult, previousRewards);
+      if (Object.keys(differential).length > 0) {
+        await this._processTokenRewardGroup(data, differential, group.config, "permit");
+      } else {
+        this.context.logger.info("No differential rewards to process for any user.");
+      }
+      this._removeTreasuryItem(result);
+    }
+    return true;
   }
 
   private _selectResultSubset(result: Result, usernames: string[]): Result {
@@ -346,11 +371,109 @@ export class PaymentModule extends BaseModule {
     }
   }
 
+  /**
+   * Extracts previous reward totals from bot comments' metadata.
+   * Parses the JSON metadata embedded in HTML comments to recover per-user totals.
+   */
+  _extractPreviousRewards(data: Readonly<IssueActivity>): {
+    [username: string]: { total: number; payoutMode: PayoutMode };
+  } {
+    const previousRewards: { [username: string]: { total: number; payoutMode: PayoutMode } } = {};
+    for (const comment of data.comments) {
+      if (!comment.body || comment.user?.type !== "Bot") continue;
+      this._parseBotCommentMetadata(comment.body, previousRewards);
+    }
+    return previousRewards;
+  }
+
+  private _parseBotCommentMetadata(
+    body: string,
+    previousRewards: { [username: string]: { total: number; payoutMode: PayoutMode } }
+  ) {
+    const metadataMatch = body.match(/<!--[\s\S]*?-->/g);
+    if (!metadataMatch) return;
+    for (const block of metadataMatch) {
+      this._extractRewardsFromMetadataBlock(block, previousRewards);
+    }
+  }
+
+  private _extractRewardsFromMetadataBlock(
+    block: string,
+    previousRewards: { [username: string]: { total: number; payoutMode: PayoutMode } }
+  ) {
+    try {
+      const jsonMatches = block.match(/\{[\s\S]*\}/g);
+      if (!jsonMatches) return;
+      for (const jsonStr of jsonMatches) {
+        this._extractRewardsFromJson(jsonStr, previousRewards);
+      }
+    } catch {
+      // Skip unparseable metadata
+    }
+  }
+
+  private _extractRewardsFromJson(
+    jsonStr: string,
+    previousRewards: { [username: string]: { total: number; payoutMode: PayoutMode } }
+  ) {
+    const parsed = JSON.parse(jsonStr);
+    const output = parsed.output ?? parsed;
+    if (typeof output !== "object" || output === null) return;
+    for (const [username, userData] of Object.entries(output)) {
+      if (typeof userData === "object" && userData !== null && "total" in userData) {
+        const payoutMode = (userData as { payoutMode?: PayoutMode }).payoutMode;
+        previousRewards[username] = {
+          total: (userData as { total: number }).total,
+          payoutMode: payoutMode ?? "permit",
+        };
+      }
+    }
+  }
+
+  /**
+   * Computes the differential between new rewards and previously distributed rewards.
+   * Returns a new Result containing only the positive differences.
+   */
+  _computeDifferential(
+    result: Result,
+    previousRewards: { [username: string]: { total: number; payoutMode: PayoutMode } }
+  ): Result {
+    const differential: Result = {};
+    for (const [username, reward] of Object.entries(result)) {
+      const previous = previousRewards[username];
+      if (!previous) {
+        differential[username] = reward;
+        continue;
+      }
+      const difference = new Decimal(reward.total).minus(previous.total).toNumber();
+      if (difference > 0) {
+        differential[username] = {
+          ...reward,
+          total: difference,
+          task: reward.task
+            ? {
+                ...reward.task,
+                reward: Math.min(difference, reward.task.reward),
+              }
+            : undefined,
+        };
+        this.context.logger.info(
+          `Differential reward for ${username}: previous=${previous.total}, new=${reward.total}, difference=${difference}`
+        );
+      } else {
+        this.context.logger.info(
+          `No additional reward for ${username}: previous=${previous.total}, new=${reward.total}`
+        );
+      }
+    }
+    return differential;
+  }
+
   /* This method returns the transfer mode based on the following conditions:
    - null: Indicates that the payout was previously transferred directly, meaning no further payout is required.
    - Permit: Applies if autoTransferMode is set to false or if rewards were previously generated using the permit method.
    - Transfer: Applies if autoTransferMode is set to true and no previous payout method has been used for the rewards.
-  */
+   */
   async _getPayoutMode(data: Readonly<IssueActivity>): Promise<PayoutMode | null> {
     for (const comment of data.comments) {
       if (comment.body && comment.user?.type === "Bot") {

--- a/tests/parser/differential-rewards.test.ts
+++ b/tests/parser/differential-rewards.test.ts
@@ -1,0 +1,243 @@
+import { beforeAll, describe, expect, it, jest } from "@jest/globals";
+import { IssueActivity } from "../../src/issue-activity";
+import { ContextPlugin } from "../../src/types/plugin-input";
+import { Result } from "../../src/types/results";
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+let PaymentModule: typeof import("../../src/parser/payment-module").PaymentModule;
+
+const DEFAULT_TIMESTAMP = "2024-01-01T00:00:00.000Z";
+const DEFAULT_URL = "https://example.test/issues/1";
+
+jest.mock("@supabase/supabase-js", () => ({
+  createClient: jest.fn(),
+}));
+
+const mockContext = {
+  config: {
+    incentives: {
+      payment: null,
+    },
+  },
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    ok: jest.fn(),
+  },
+  env: {},
+} as unknown as ContextPlugin;
+
+beforeAll(async () => {
+  ({ PaymentModule } = await import("../../src/parser/payment-module"));
+});
+
+function makeResult(users: { [k: string]: { total: number; taskReward?: number; userId: number } }): Result {
+  const result: Result = {};
+  for (const [username, data] of Object.entries(users)) {
+    result[username] = {
+      total: data.total,
+      userId: data.userId,
+      task: data.taskReward
+        ? {
+            reward: data.taskReward,
+            multiplier: 1,
+            timestamp: DEFAULT_TIMESTAMP,
+            url: DEFAULT_URL,
+          }
+        : undefined,
+    };
+  }
+  return result;
+}
+
+describe("Differential Reward Distribution", () => {
+  let paymentModule: InstanceType<typeof PaymentModule>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    paymentModule = new PaymentModule(mockContext);
+  });
+
+  describe("_extractPreviousRewards", () => {
+    it("should extract previous rewards from bot comment metadata", () => {
+      const metadata = `<!-- Ubiquity - GithubCommentModule - someCaller - abc123
+{
+  "workflowUrl": "https://github.com/test",
+  "output": {
+    "user1": {
+      "total": 100,
+      "payoutMode": "transfer",
+      "userId": 1
+    },
+    "user2": {
+      "total": 50,
+      "payoutMode": "transfer",
+      "userId": 2
+    }
+  }
+}
+-->`;
+      const data = {
+        comments: [
+          {
+            body: metadata,
+            user: { type: "Bot" as const },
+          },
+        ],
+      } as unknown as IssueActivity;
+
+      const result = paymentModule._extractPreviousRewards(data);
+      expect(result).toEqual({
+        user1: { total: 100, payoutMode: "transfer" },
+        user2: { total: 50, payoutMode: "transfer" },
+      });
+    });
+
+    it("should return empty object when no bot comments exist", () => {
+      const data = {
+        comments: [
+          {
+            body: "Regular user comment",
+            user: { type: "User" as const },
+          },
+        ],
+      } as unknown as IssueActivity;
+
+      const result = paymentModule._extractPreviousRewards(data);
+      expect(result).toEqual({});
+    });
+
+    it("should return empty object when bot comment has no metadata", () => {
+      const data = {
+        comments: [
+          {
+            body: "Bot comment without metadata",
+            user: { type: "Bot" as const },
+          },
+        ],
+      } as unknown as IssueActivity;
+
+      const result = paymentModule._extractPreviousRewards(data);
+      expect(result).toEqual({});
+    });
+
+    it("should handle multiple bot comments and use the latest data", () => {
+      const comment1 = `<!-- Ubiquity - GithubCommentModule - caller - abc
+{
+  "workflowUrl": "https://github.com/test",
+  "output": {
+    "user1": { "total": 80, "payoutMode": "permit", "userId": 1 }
+  }
+}
+-->`;
+      const comment2 = `<!-- Ubiquity - GithubCommentModule - caller - def
+{
+  "workflowUrl": "https://github.com/test",
+  "output": {
+    "user1": { "total": 100, "payoutMode": "transfer", "userId": 1 }
+  }
+}
+-->`;
+      const data = {
+        comments: [
+          { body: comment1, user: { type: "Bot" as const } },
+          { body: comment2, user: { type: "Bot" as const } },
+        ],
+      } as unknown as IssueActivity;
+
+      const result = paymentModule._extractPreviousRewards(data);
+      // Last comment wins
+      expect(result.user1).toEqual({ total: 100, payoutMode: "transfer" });
+    });
+
+    it("should default payoutMode to permit when not specified", () => {
+      const metadata = `<!-- Ubiquity - GithubCommentModule - caller - abc
+{
+  "output": {
+    "user1": { "total": 50, "userId": 1 }
+  }
+}
+-->`;
+      const data = {
+        comments: [{ body: metadata, user: { type: "Bot" as const } }],
+      } as unknown as IssueActivity;
+
+      const result = paymentModule._extractPreviousRewards(data);
+      expect(result.user1).toEqual({ total: 50, payoutMode: "permit" });
+    });
+  });
+
+  describe("_computeDifferential", () => {
+    it("should include full amount for new beneficiaries", () => {
+      const result = makeResult({ user1: { total: 100, userId: 1 } });
+      const previousRewards: Record<string, { total: number; payoutMode: "transfer" | "permit" }> = {};
+
+      const differential = paymentModule._computeDifferential(result, previousRewards);
+      expect(differential.user1.total).toBe(100);
+    });
+
+    it("should compute positive difference for existing beneficiaries", () => {
+      const result = makeResult({ user1: { total: 150, userId: 1 } });
+      const previousRewards = { user1: { total: 100, payoutMode: "transfer" as const } };
+
+      const differential = paymentModule._computeDifferential(result, previousRewards);
+      expect(differential.user1.total).toBe(50);
+    });
+
+    it("should exclude beneficiaries with no change", () => {
+      const result = makeResult({ user1: { total: 100, userId: 1 } });
+      const previousRewards = { user1: { total: 100, payoutMode: "transfer" as const } };
+
+      const differential = paymentModule._computeDifferential(result, previousRewards);
+      expect(differential.user1).toBeUndefined();
+    });
+
+    it("should exclude beneficiaries with decreased reward", () => {
+      const result = makeResult({ user1: { total: 80, userId: 1 } });
+      const previousRewards = { user1: { total: 100, payoutMode: "transfer" as const } };
+
+      const differential = paymentModule._computeDifferential(result, previousRewards);
+      expect(differential.user1).toBeUndefined();
+    });
+
+    it("should handle mixed scenario: new, increased, decreased, unchanged", () => {
+      const result = makeResult({
+        user1: { total: 150, userId: 1 }, // +50
+        user2: { total: 50, userId: 2 }, // unchanged
+        user3: { total: 25, userId: 3 }, // new
+        user4: { total: 30, userId: 4 }, // decreased from 50
+      });
+      const previousRewards = {
+        user1: { total: 100, payoutMode: "transfer" as const },
+        user2: { total: 50, payoutMode: "transfer" as const },
+        user4: { total: 50, payoutMode: "transfer" as const },
+      };
+
+      const differential = paymentModule._computeDifferential(result, previousRewards);
+      expect(differential.user1.total).toBe(50);
+      expect(differential.user2).toBeUndefined();
+      expect(differential.user3.total).toBe(25);
+      expect(differential.user4).toBeUndefined();
+    });
+
+    it("should cap task reward at the difference amount", () => {
+      const result = makeResult({ user1: { total: 150, taskReward: 100, userId: 1 } });
+      const previousRewards = { user1: { total: 100, payoutMode: "transfer" as const } };
+
+      const differential = paymentModule._computeDifferential(result, previousRewards);
+      expect(differential.user1.total).toBe(50);
+      expect(differential.user1.task?.reward).toBe(50); // capped at difference
+    });
+
+    it("should keep task reward if less than difference", () => {
+      const result = makeResult({ user1: { total: 150, taskReward: 30, userId: 1 } });
+      const previousRewards = { user1: { total: 100, payoutMode: "transfer" as const } };
+
+      const differential = paymentModule._computeDifferential(result, previousRewards);
+      expect(differential.user1.total).toBe(50);
+      expect(differential.user1.task?.reward).toBe(30); // kept as-is since < difference
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements differential reward distribution for reopened issues as specified in #301.

When an issue is reopened and closed again, the reward system now calculates and distributes only the **difference** between previously granted rewards and new rewards.

### Changes

`src/parser/payment-module.ts`:
- **`_extractPreviousRewards()`**: Extracts previous reward totals from bot comments HTML metadata
- **`_computeDifferential()`**: Computes positive differences between new and previous rewards
- **`_handleDifferentialRewards()`**: Orchestrates differential processing, falls back to permit mode

### Logic Flow

1. When `_getPayoutMode()` returns `null` (previous direct transfer detected):
   - Extracts previous reward amounts from bot comment metadata
   - Computes per-user differential (new total - previous total)
   - Only processes payments for users with positive differences
   - Uses permit mode for differential payouts

### Test Coverage

12 new tests in `tests/parser/differential-rewards.test.ts`:
- Metadata extraction (5 tests)
- Differential computation (7 tests)

### Example

```
Previous: { user1: 100, user2: 50 }
New:      { user1: 150, user2: 50, user3: 25 }
Result:   { user1: +50, user3: +25 }  // user2 skipped (no change)
```

Closes: #301

---
Bounty: #301 ($300)