### PR TITLE
Include research rewards for disqualified assignees

### DIFF
--- a/src/configuration/data-purge-config.ts
+++ b/src/configuration/data-purge-config.ts
@@ -10,6 +10,10 @@ export const dataPurgeConfigurationType = Type.Object({
       "- 'none': Includes all comments, regardless of assignment status or timing.",
     examples: ["all", "exact", "none"],
   }),
+  includeResearchOnDisqualification: Type.Boolean({
+    default: false,
+    description: "Includes comments of assignees who were disqualified (unassigned) without finishing the task.",
+  }),
 });
 
 export type DataPurgeConfiguration = Static<typeof dataPurgeConfigurationType>;

--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -29,22 +29,36 @@ export class DataPurgeModule extends BaseModule {
       this.context.logger.debug("Skipping hidden comment", { comment });
       return true;
     }
+
+    const userLogin = comment.user?.login;
+
     if (
       this._configuration?.skipCommentsWhileAssigned &&
       this._configuration.skipCommentsWhileAssigned !== "none" &&
-      comment.user?.login &&
-      !(comment.commentType & CommentAssociation.SPECIFICATION) &&
-      isCommentDuringAssignment(
-        comment,
-        this._assignmentPeriods[comment.user?.login],
-        this._configuration.skipCommentsWhileAssigned === "exact"
-      )
+      userLogin &&
+      !(comment.commentType & CommentAssociation.SPECIFICATION)
     ) {
-      this.context.logger.debug("Skipping comment during assignment", {
-        body: comment.body?.replace(/(.{100})..+/, "$1…"),
-        url: comment.html_url,
-      });
-      return true;
+      const isAssigned = isCommentDuringAssignment(
+        comment,
+        this._assignmentPeriods[userLogin],
+        this._configuration.skipCommentsWhileAssigned === "exact"
+      );
+
+      if (isAssigned) {
+        if (this._configuration.includeResearchOnDisqualification) {
+          const currentAssignees = this.context.payload.issue?.assignees?.map((a: { login: string }) => a.login) ?? [];
+          if (!currentAssignees.includes(userLogin)) {
+            this.context.logger.debug("Including research comment for disqualified user", { userLogin });
+            return false;
+          }
+        }
+
+        this.context.logger.debug("Skipping comment during assignment", {
+          body: comment.body?.replace(/(.{100})..+/, "$1…"),
+          url: comment.html_url,
+        });
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
Implements #296 by adding a new configuration option .

When enabled, the plugin will include comments made during assignment periods for users who are NOT currently assigned to the issue at the time of closing. This ensures that contributors who spent time researching but were disqualified (e.g., due to deadline expiration) still receive credit for their valuable research comments.

Resolves #296.