### PR TITLE
fix: clear error message when token contract not found on network

### DIFF
--- a/src/parser/github-comment-module.ts
+++ b/src/parser/github-comment-module.ts
@@ -77,9 +77,22 @@ export class GithubCommentModule extends BaseModule {
       return cached;
     }
     const tokenContract = await getContract(config.evmNetworkId, config.erc20RewardToken, ERC20_ABI);
-    const symbol = await new Erc20Wrapper(tokenContract).getSymbol();
-    this._tokenSymbolCache.set(key, symbol);
-    return symbol;
+    try {
+      const symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+      this._tokenSymbolCache.set(key, symbol);
+      return symbol;
+    } catch (error: unknown) {
+      // Check if this is a CALL_EXCEPTION (contract doesn't exist on this network)
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      if (errorMessage.includes('CALL_EXCEPTION') || errorMessage.includes('call revert')) {
+        throw new Error(
+          `Token contract ${config.erc20RewardToken} not found on network ID ${config.evmNetworkId}. ` +
+          `Please verify the token address and network ID are correct.`
+        );
+      }
+      // Re-throw if it's a different error
+      throw error;
+    }
   }
 
   private async _getTokenDisplayForUser(username: string) {


### PR DESCRIPTION
Fixes #271

## Problem
When a token contract doesn't exist on the configured network, the error message is cryptic:
`Error: call revert exception [method="symbol()", code=CALL_EXCEPTION]`

## Solution
Catch the CALL_EXCEPTION error and provide a clear, actionable error message:
`Token contract 0x... not found on network ID X. Please verify the token address and network ID are correct.`

## Changes
- Modified `_getTokenSymbolForConfig` in `src/parser/github-comment-module.ts`
- Added try-catch block to handle CALL_EXCEPTION errors
- Provides user-friendly error message with token address and network ID

## Testing
The fix handles the error case when:\n- Token contract address is invalid\n- Token contract doesn't exist on the specified network\n- Network ID is incorrect