### PR TITLE
fix: tighten reward collaboration gating

### DIFF
--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -1,4 +1,4 @@
-import { GitHubPullRequest, GitHubPullRequestReviewState } from "../github-types";
+import { GitHubPullRequest } from "../github-types";
 import { IssueActivity } from "../issue-activity";
 import { ContextPlugin } from "../types/plugin-input";
 
@@ -7,38 +7,51 @@ export function isCollaborative(data: Readonly<IssueActivity>) {
   const issueCreator = data.self.user;
 
   if (data.self.closed_by.id === issueCreator.id) {
-    const pricingEventsByNonAssignee = data.events.find(
+    const pricingEventsByDifferentHuman = data.events.find(
       (event) =>
         event.event === "labeled" &&
         "label" in event &&
         (event.label.name.startsWith("Time: ") || event.label.name.startsWith("Priority: ")) &&
-        event.actor.id !== issueCreator.id
+        event.actor?.id !== issueCreator.id &&
+        event.actor?.type === "User"
     );
-    return !!pricingEventsByNonAssignee || !!nonAssigneeApprovedReviews(data);
+    return !!pricingEventsByDifferentHuman || nonAssigneeApprovedReviews(data);
   }
   return true;
 }
 
 export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {
-  if (data.linkedMergedPullRequests[0] && data.self?.assignee) {
-    const pullRequest = data.linkedMergedPullRequests[0].self;
-    const pullReview = data.linkedMergedPullRequests[0];
-    const reviewsByNonAssignee: GitHubPullRequestReviewState[] = [];
-    const assignee = data.self.assignee;
-    type RequestedReviewer = NonNullable<GitHubPullRequest["requested_reviewers"]>[number];
-
-    if (pullReview.reviews && pullRequest) {
-      for (const review of pullReview.reviews) {
-        const isReviewRequestedForUser =
-          "requested_reviewers" in pullRequest &&
-          pullRequest.requested_reviewers?.some((reviewer: RequestedReviewer) => reviewer.id === review.user?.id);
-        if (!isReviewRequestedForUser && review.user?.id) {
-          reviewsByNonAssignee.push(review);
-        }
-      }
-    }
-    return reviewsByNonAssignee.filter((v) => v.user?.id !== assignee.id && v.state === "APPROVED");
+  if (!data.linkedMergedPullRequests[0]) {
+    return false;
   }
+
+  const pullRequest = data.linkedMergedPullRequests[0].self;
+  const pullReview = data.linkedMergedPullRequests[0];
+  type RequestedReviewer = NonNullable<GitHubPullRequest["requested_reviewers"]>[number];
+
+  const assigneeIds = new Set<number>([
+    ...(data.self?.assignees?.map((assignee) => assignee.id) ?? []),
+    ...(data.self?.assignee?.id ? [data.self.assignee.id] : []),
+  ]);
+
+  if (!pullReview.reviews || !pullRequest) {
+    return false;
+  }
+
+  for (const review of pullReview.reviews) {
+    const isReviewRequestedForUser =
+      "requested_reviewers" in pullRequest &&
+      pullRequest.requested_reviewers?.some((reviewer: RequestedReviewer) => reviewer.id === review.user?.id);
+
+    if (isReviewRequestedForUser || !review.user?.id || review.user.type !== "User") {
+      continue;
+    }
+
+    if (review.state === "APPROVED" && !assigneeIds.has(review.user.id)) {
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/tests/helpers/checkers.test.ts
+++ b/tests/helpers/checkers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "@jest/globals";
+import { isCollaborative, nonAssigneeApprovedReviews } from "../../src/helpers/checkers";
+import { IssueActivity } from "../../src/issue-activity";
+
+type PartialIssueActivity = Partial<IssueActivity> & {
+  self?: Record<string, unknown>;
+  events?: Array<Record<string, unknown>>;
+  linkedMergedPullRequests?: Array<Record<string, unknown>>;
+};
+
+function buildActivity(overrides: PartialIssueActivity = {}) {
+  const base: PartialIssueActivity = {
+    self: {
+      closed_by: { id: 1 },
+      user: { id: 1 },
+      assignee: { id: 1 },
+      assignees: [{ id: 1 }],
+    },
+    events: [],
+    linkedMergedPullRequests: [],
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    self: {
+      ...base.self,
+      ...(overrides.self ?? {}),
+    },
+  } as IssueActivity;
+}
+
+describe("checkers collaboration gating", () => {
+  it("does not count bot-applied pricing labels as human collaboration", () => {
+    const activity = buildActivity({
+      events: [
+        {
+          event: "labeled",
+          label: { name: "Priority: 2 (Medium)" },
+          actor: { id: 999, type: "Bot" },
+        },
+      ],
+    });
+
+    expect(isCollaborative(activity)).toBe(false);
+  });
+
+  it("does not treat empty non-assignee review matches as collaborative", () => {
+    const activity = buildActivity({
+      linkedMergedPullRequests: [
+        {
+          self: { requested_reviewers: [] },
+          reviews: [
+            {
+              state: "COMMENTED",
+              user: { id: 2, type: "User" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+    expect(isCollaborative(activity)).toBe(false);
+  });
+
+  it("counts approved reviews from a different human as collaborative", () => {
+    const activity = buildActivity({
+      linkedMergedPullRequests: [
+        {
+          self: { requested_reviewers: [] },
+          reviews: [
+            {
+              state: "APPROVED",
+              user: { id: 2, type: "User" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(nonAssigneeApprovedReviews(activity)).toBe(true);
+    expect(isCollaborative(activity)).toBe(true);
+  });
+});


### PR DESCRIPTION
Summary
- ignore bot-applied Time/Priority labels when checking collaboration
- make nonAssigneeApprovedReviews return a boolean instead of a truthy array
- treat only approved reviews from a different human assignee as collaboration
- add focused regression tests for issue #455

Why
- #455 reports rewards being generated without real human collaboration
- the current logic treats bot label events as collaboration and also treats an empty filtered review array as truthy

Tests
- node node_modules/jest/bin/jest.js tests/helpers/checkers.test.ts --runInBand
- node node_modules/jest/bin/jest.js tests/payment-generatable.test.ts --runInBand

Related
- Fixes #455