### PR TITLE
fix: support PR collaboration review checks

### DIFF
--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -2,6 +2,11 @@ import { GitHubPullRequest, GitHubPullRequestReviewState } from "../github-types
 import { IssueActivity } from "../issue-activity";
 import { ContextPlugin } from "../types/plugin-input";
 
+type RequestedReviewer = NonNullable<GitHubPullRequest["requested_reviewers"]>[number];
+type ReviewAuthorAssociation = NonNullable<GitHubPullRequestReviewState["author_association"]>;
+
+const COLLABORATOR_REVIEW_ASSOCIATIONS: ReviewAuthorAssociation[] = ["COLLABORATOR", "MEMBER", "OWNER"];
+
 export function isCollaborative(data: Readonly<IssueActivity>) {
   if (!data.self?.closed_by || !data.self.user) return false;
   const issueCreator = data.self.user;
@@ -20,26 +25,74 @@ export function isCollaborative(data: Readonly<IssueActivity>) {
 }
 
 export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {
-  if (data.linkedMergedPullRequests[0] && data.self?.assignee) {
-    const pullRequest = data.linkedMergedPullRequests[0].self;
-    const pullReview = data.linkedMergedPullRequests[0];
-    const reviewsByNonAssignee: GitHubPullRequestReviewState[] = [];
-    const assignee = data.self.assignee;
-    type RequestedReviewer = NonNullable<GitHubPullRequest["requested_reviewers"]>[number];
-
-    if (pullReview.reviews && pullRequest) {
-      for (const review of pullReview.reviews) {
-        const isReviewRequestedForUser =
-          "requested_reviewers" in pullRequest &&
-          pullRequest.requested_reviewers?.some((reviewer: RequestedReviewer) => reviewer.id === review.user?.id);
-        if (!isReviewRequestedForUser && review.user?.id) {
-          reviewsByNonAssignee.push(review);
-        }
-      }
-    }
-    return reviewsByNonAssignee.filter((v) => v.user?.id !== assignee.id && v.state === "APPROVED");
+  const linkedPullRequest = data.linkedMergedPullRequests[0];
+  if (!linkedPullRequest) {
+    return false;
   }
-  return false;
+
+  if (data.self?.pull_request) {
+    const pullRequestAuthorId = linkedPullRequest.self?.user?.id ?? data.self.user?.id;
+    const excludedAuthorIds = new Set(
+      [pullRequestAuthorId, ...data.linkedIssues.map((issue) => issue.node.author?.id)].filter(Boolean).map(String)
+    );
+    return hasApprovedReviewByCollaborator(linkedPullRequest.reviews, excludedAuthorIds);
+  }
+
+  const assigneeId = data.self?.assignee?.id;
+  if (!assigneeId || !linkedPullRequest.self) {
+    return false;
+  }
+
+  return hasIssueContextApprovedReview(linkedPullRequest.self, linkedPullRequest.reviews, assigneeId);
+}
+
+function hasApprovedReviewByCollaborator(
+  reviews: GitHubPullRequestReviewState[] | null | undefined,
+  excludedUserIds: Set<string>
+) {
+  if (!reviews) {
+    return false;
+  }
+
+  return reviews.some(
+    (review) =>
+      Boolean(review.user?.id) &&
+      !excludedUserIds.has(String(review.user?.id)) &&
+      review.state === "APPROVED" &&
+      isReviewByCollaborator(review)
+  );
+}
+
+function hasIssueContextApprovedReview(
+  pullRequest: GitHubPullRequest,
+  reviews: GitHubPullRequestReviewState[] | null | undefined,
+  assigneeId: number
+) {
+  if (!reviews) {
+    return false;
+  }
+
+  return reviews.some(
+    (review) =>
+      Boolean(review.user?.id) &&
+      review.user?.id !== assigneeId &&
+      review.state === "APPROVED" &&
+      !isReviewRequestedForUser(pullRequest, review)
+  );
+}
+
+function isReviewRequestedForUser(pullRequest: GitHubPullRequest, review: GitHubPullRequestReviewState) {
+  if (!("requested_reviewers" in pullRequest)) {
+    return false;
+  }
+
+  return (
+    pullRequest.requested_reviewers?.some((reviewer: RequestedReviewer) => reviewer.id === review.user?.id) ?? false
+  );
+}
+
+function isReviewByCollaborator(review: GitHubPullRequestReviewState) {
+  return COLLABORATOR_REVIEW_ASSOCIATIONS.includes(review.author_association as ReviewAuthorAssociation);
 }
 
 /*

--- a/tests/helpers/checkers.test.ts
+++ b/tests/helpers/checkers.test.ts
@@ -1,0 +1,151 @@
+import { isCollaborative, nonAssigneeApprovedReviews } from "../../src/helpers/checkers";
+import type { GitHubPullRequestReviewState } from "../../src/github-types";
+import type { IssueActivity } from "../../src/issue-activity";
+
+type User = {
+  id: number;
+  login: string;
+};
+
+const author = { id: 1, login: "author" };
+const assignee = { id: 2, login: "assignee" };
+const reviewer = { id: 3, login: "reviewer" };
+const issueAuthor = { id: 4, login: "issue-author" };
+const outsideReviewer = { id: 5, login: "outside-reviewer" };
+
+function createReview(
+  user: User,
+  state: GitHubPullRequestReviewState["state"] = "APPROVED",
+  authorAssociation: GitHubPullRequestReviewState["author_association"] = "MEMBER"
+) {
+  return {
+    author_association: authorAssociation,
+    state,
+    user,
+  } as GitHubPullRequestReviewState;
+}
+
+function createActivity({
+  pullRequestContext = false,
+  issueAssignee,
+  linkedIssueAuthor,
+  reviews = [],
+  requestedReviewers = [],
+}: {
+  pullRequestContext?: boolean;
+  issueAssignee?: User;
+  linkedIssueAuthor?: User;
+  reviews?: GitHubPullRequestReviewState[];
+  requestedReviewers?: User[];
+}) {
+  return {
+    self: {
+      user: author,
+      closed_by: author,
+      assignee: issueAssignee,
+      pull_request: pullRequestContext ? { html_url: "https://github.com/owner/repo/pull/1" } : undefined,
+    },
+    events: [],
+    linkedMergedPullRequests: [
+      {
+        self: {
+          user: author,
+          requested_reviewers: requestedReviewers,
+        },
+        reviews,
+      },
+    ],
+    linkedIssues: linkedIssueAuthor
+      ? [
+          {
+            node: {
+              author: linkedIssueAuthor,
+            },
+          },
+        ]
+      : [],
+  } as unknown as Readonly<IssueActivity>;
+}
+
+describe("collaboration checks", () => {
+  describe("nonAssigneeApprovedReviews", () => {
+    it("uses PR reviews when the reward context is a pull request without assignees", () => {
+      const activity = createActivity({
+        pullRequestContext: true,
+        reviews: [createReview(reviewer)],
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(true);
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("does not count the PR author's own approval in pull request context", () => {
+      const activity = createActivity({
+        pullRequestContext: true,
+        reviews: [createReview(author)],
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count non-collaborator approvals in pull request context", () => {
+      const activity = createActivity({
+        pullRequestContext: true,
+        reviews: [createReview(reviewer, "APPROVED", "CONTRIBUTOR"), createReview(outsideReviewer, "APPROVED", "NONE")],
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count linked issue author's approval in pull request context", () => {
+      const activity = createActivity({
+        pullRequestContext: true,
+        linkedIssueAuthor: issueAuthor,
+        reviews: [createReview(issueAuthor)],
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count review comments as approved reviews in pull request context", () => {
+      const activity = createActivity({
+        pullRequestContext: true,
+        reviews: [createReview(reviewer, "COMMENTED"), createReview(author, "COMMENTED")],
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not treat an empty PR review list as collaborative", () => {
+      const activity = createActivity({
+        pullRequestContext: true,
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("keeps the issue-context assignee behavior", () => {
+      const activity = createActivity({
+        issueAssignee: assignee,
+        reviews: [createReview(reviewer)],
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(true);
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("does not treat an empty issue-context review list as collaborative", () => {
+      const activity = createActivity({
+        issueAssignee: assignee,
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve the existing issue-context collaboration check that compares linked PR approvals against the issue assignee.
- Add a pull-request-context path so unassigned PR reward runs use PR review data instead of `data.self.assignee`.
- In PR context, only count an `APPROVED` review when the reviewer is a GitHub `OWNER`, `MEMBER`, or `COLLABORATOR` and is neither the PR author nor a linked issue author.
- Normalize `nonAssigneeApprovedReviews` to return a boolean so empty review lists cannot count as collaborative.
- Add focused helper coverage for PR-context and issue-context behavior.

## Root Cause
In pull-request reward context, `data.self` is the PR issue object. Unassigned PRs therefore have no `data.self.assignee`, so the previous `nonAssigneeApprovedReviews` branch returned `false` before inspecting the actual PR reviews. That caused author-merged PRs with valid external collaborator approvals to be marked non-collaborative.

Closes #527

## E2E Tests
Live repository: `Meniole/text-conversation-rewards`

### Positive: collaborator approval counts
PR: https://github.com/Meniole/text-conversation-rewards/pull/40

Live-data shape:

```json
{
  "repository": "Meniole/text-conversation-rewards",
  "pullRequest": "https://github.com/Meniole/text-conversation-rewards/pull/40",
  "pullRequestMerged": true,
  "pullRequestAuthor": "ubiquity-ubiquibot",
  "closedBy": "ubiquity-ubiquibot",
  "assignees": [],
  "linkedIssueAuthors": ["ubiquity-ubiquibot"],
  "approvedReviews": [
    {
      "reviewer": "gentlementlegen",
      "authorAssociation": "MEMBER"
    }
  ],
  "nonAssigneeApprovedReviews": true,
  "isCollaborative": true
}
```

### Negative: non-collaborator approval does not count
PR: https://github.com/Meniole/text-conversation-rewards/pull/270

Live-data shape:

```json
{
  "repository": "Meniole/text-conversation-rewards",
  "pullRequest": "https://github.com/Meniole/text-conversation-rewards/pull/270",
  "pullRequestMerged": true,
  "pullRequestAuthor": "gentlementlegen",
  "closedBy": "gentlementlegen",
  "assignees": [],
  "approvedReviews": [
    {
      "reviewer": "ubiquity-ubiquibot",
      "authorAssociation": "NONE"
    }
  ],
  "nonAssigneeApprovedReviews": false,
  "isCollaborative": false
}
```

This verifies both sides of the PR-context rule: collaborator approvals count, non-collaborator approvals do not.

E2E on a real use-case scenario: https://github.com/ubiquity/uusd.ubq.fi/pull/43#issuecomment-4332917528

## Verification
- `npx eslint src/helpers/checkers.ts tests/helpers/checkers.test.ts`
- `npx tsc --noEmit`
- `npx jest tests/payment-generatable.test.ts tests/helpers/checkers.test.ts --runInBand`
