### PR TITLE
fix: ignore multiline slash commands in rewards

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -9,6 +9,41 @@ import { Result, GithubCommentScore as ResultComment } from "../types/results";
 
 type CommentType = Awaited<ReturnType<IssueActivity["getAllComments"]>>[0];
 
+export function cleanCommentBody(body: string): string {
+  const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+  return body
+    .split(/\r?\n/)
+    .reduce<{ lines: string[]; skippingCommand: boolean }>(
+      (acc, line) => {
+        const isCommandLine = /^\s*\/\S+/.test(line);
+        if (isCommandLine) {
+          return { ...acc, skippingCommand: true };
+        }
+        if (acc.skippingCommand) {
+          if (line.trim() === "") {
+            return { ...acc, skippingCommand: false };
+          }
+          return acc;
+        }
+        acc.lines.push(line);
+        return acc;
+      },
+      { lines: [], skippingCommand: false }
+    )
+    .lines.join("\n")
+    // Remove quoted text
+    .replace(/^>.*$/gm, "")
+    // Remove HTML comments
+    .replace(/<!--[\s\S]*?-->/g, "")
+    // Remove the footnotes
+    .replace(/^###### .*?\[\^\d+\^][\s\S]*$/gm, "")
+    .replace(/^\[\^[\w-]+\^?]:.*$/gm, "")
+    .replace(/\[\^[\w-]+\^?]/g, "")
+    // Make sure links are all in the MD link format, except the ones contained in HTML elements
+    .replaceAll(urlRegex, "[$1]($1)")
+    .trim();
+}
+
 /**
  * Removes the data in the comments that we do not want to be processed.
  */
@@ -50,23 +85,7 @@ export class DataPurgeModule extends BaseModule {
   }
 
   private _cleanCommentBody(body: string): string {
-    const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
-    return (
-      body
-        // Remove quoted text
-        .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
-        // Remove HTML comments
-        .replace(/<!--[\s\S]*?-->/g, "")
-        // Remove the footnotes
-        .replace(/^###### .*?\[\^\d+\^][\s\S]*$/gm, "")
-        .replace(/^\[\^[\w-]+\^?]:.*$/gm, "")
-        .replace(/\[\^[\w-]+\^?]/g, "")
-        // Make sure links are all in the MD link format, except the ones contained in HTML elements
-        .replaceAll(urlRegex, "[$1]($1)")
-        .trim()
-    );
+    return cleanCommentBody(body);
   }
 
   private _createResultComment(comment: CommentType, newContent: string): ResultComment | null {

--- a/tests/data-purge-clean-comment.test.ts
+++ b/tests/data-purge-clean-comment.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "@jest/globals";
+import { cleanCommentBody } from "../src/parser/data-purge-module";
+
+describe("cleanCommentBody", () => {
+  it("removes multiline slash command blocks from rewardable comment text", () => {
+    const body = [
+      "/ask can you check this?",
+      "This line is command context and should not be rewarded.",
+      "Another command detail should be removed.",
+      "",
+      "This follow-up is a normal comment with https://example.com",
+    ].join("\n");
+
+    expect(cleanCommentBody(body)).toBe("This follow-up is a normal comment with [https://example.com](https://example.com)");
+  });
+
+  it("removes an entire slash command comment when no normal text follows", () => {
+    expect(cleanCommentBody("/ask\nscore this hidden command context")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- strip slash-command blocks before rewardable comment evaluation
- remove continuation lines after commands like `/ask` until a blank line is reached
- keep normal comment text after the command block and preserve existing URL/quote/footnote cleanup
- add focused regression coverage for multiline command comments

## Validation
- `npx jest tests/data-purge-clean-comment.test.ts --runInBand`
- `npx tsc --noEmit` after generating `src/types/rpcs.json` manually because `bun` is not installed locally
- `git diff --check`

Resolves #242
/claim #242