### PR TITLE
fix: validate reward generation requires human collaborator - Bounty #455 ()

### DIFF
--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -7,21 +7,75 @@ type ReviewAuthorAssociation = NonNullable<GitHubPullRequestReviewState["author_
 
 const COLLABORATOR_REVIEW_ASSOCIATIONS: ReviewAuthorAssociation[] = ["COLLABORATOR", "MEMBER", "OWNER"];
 
+/**
+ * Well-known bot account patterns used by the UbiquityOS ecosystem.
+ * These accounts perform automated actions (labeling, closing) and should
+ * NOT count as human collaboration.
+ */
+const BOT_LOGIN_PATTERNS = ["ubiquity-os", "ubiquity-os-beta", "github-actions[bot]", "dependabot[bot]", "vercel[bot]"];
+
+function isBotAccount(user: { login?: string; id?: number } | null | undefined): boolean {
+  if (!user?.login) return false;
+  const login = user.login.toLowerCase();
+  return BOT_LOGIN_PATTERNS.some((pattern) => login === pattern || login.endsWith("[bot]"));
+}
+
+/**
+ * Checks if the task had human collaborator involvement beyond the assignee/contributor.
+ * This prevents a contributor from single-handedly generating rewards without oversight.
+ *
+ * A task is considered collaborative if ALL of the following are true:
+ * - The issue was closed by a real human (not a bot)
+ * AND at least ONE of the following:
+ * 1. The closer is someone other than the issue creator
+ * 2. Someone other than the creator and assignees set pricing labels (Time/Priority)
+ * 3. Someone other than the creator and assignees assigned the issue
+ * 4. A non-assignee approved review exists on the linked PR
+ */
 export function isCollaborative(data: Readonly<IssueActivity>) {
   if (!data.self?.closed_by || !data.self.user) return false;
   const issueCreator = data.self.user;
+  const closedBy = data.self.closed_by;
 
-  if (data.self.closed_by.id === issueCreator.id) {
-    const pricingEventsByNonAssignee = data.events.find(
-      (event) =>
-        event.event === "labeled" &&
-        "label" in event &&
-        (event.label.name.startsWith("Time: ") || event.label.name.startsWith("Priority: ")) &&
-        event.actor.id !== issueCreator.id
-    );
-    return !!pricingEventsByNonAssignee || !!nonAssigneeApprovedReviews(data);
+  // Bot-closed issues do not count as collaborative
+  if (isBotAccount(closedBy)) {
+    return false;
   }
-  return true;
+
+  // Assignee IDs to exclude from collaborator checks (besides the creator)
+  const assigneeIds = new Set(
+    (data.self.assignees ?? []).map((a) => a?.id).filter((id): id is number => typeof id === "number")
+  );
+
+  // If closed by someone other than the creator, that's already collaborative
+  if (closedBy.id !== issueCreator.id) {
+    return true;
+  }
+
+  // Check pricing labels set by a real human who is NOT the creator or an assignee
+  const pricingEventsByNonAssignee = data.events.find(
+    (event) =>
+      event.event === "labeled" &&
+      "label" in event &&
+      (event.label.name.startsWith("Time: ") || event.label.name.startsWith("Priority: ")) &&
+      event.actor.id !== issueCreator.id &&
+      !assigneeIds.has(event.actor.id) &&
+      !isBotAccount(event.actor)
+  );
+  if (pricingEventsByNonAssignee) return true;
+
+  // Check if someone other than the creator and assignees assigned the issue
+  const assignmentByNonAssignee = data.events.find(
+    (event) =>
+      event.event === "assigned" &&
+      event.actor.id !== issueCreator.id &&
+      !assigneeIds.has(event.actor.id) &&
+      !isBotAccount(event.actor)
+  );
+  if (assignmentByNonAssignee) return true;
+
+  // Check for approved reviews by a non-assignee collaborator
+  return !!nonAssigneeApprovedReviews(data);
 }
 
 export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {

--- a/tests/helpers/checkers.test.ts
+++ b/tests/helpers/checkers.test.ts
@@ -12,6 +12,10 @@ const assignee = { id: 2, login: "assignee" };
 const reviewer = { id: 3, login: "reviewer" };
 const issueAuthor = { id: 4, login: "issue-author" };
 const outsideReviewer = { id: 5, login: "outside-reviewer" };
+const botUser = { id: 100, login: "ubiquity-os" };
+const botBeta = { id: 101, login: "ubiquity-os-beta" };
+const ghActionsBot = { id: 102, login: "github-actions[bot]" };
+const humanCollaborator = { id: 6, login: "human-collaborator" };
 
 function createReview(
   user: User,
@@ -28,24 +32,31 @@ function createReview(
 function createActivity({
   pullRequestContext = false,
   issueAssignee,
+  assignees,
   linkedIssueAuthor,
   reviews = [],
   requestedReviewers = [],
+  closedBy,
+  events = [],
 }: {
   pullRequestContext?: boolean;
   issueAssignee?: User;
+  assignees?: User[];
   linkedIssueAuthor?: User;
   reviews?: GitHubPullRequestReviewState[];
   requestedReviewers?: User[];
+  closedBy?: User;
+  events?: Array<{ event: string; actor: User; label?: { name: string } }>;
 }) {
   return {
     self: {
       user: author,
-      closed_by: author,
+      closed_by: closedBy ?? author,
       assignee: issueAssignee,
+      assignees: assignees,
       pull_request: pullRequestContext ? { html_url: "https://github.com/owner/repo/pull/1" } : undefined,
     },
-    events: [],
+    events: events,
     linkedMergedPullRequests: [
       {
         self: {
@@ -146,6 +157,95 @@ describe("collaboration checks", () => {
 
       expect(nonAssigneeApprovedReviews(activity)).toBe(false);
       expect(isCollaborative(activity)).toBe(false);
+    });
+  });
+
+  describe("bot detection", () => {
+    it("does not count bot-closed issues as collaborative", () => {
+      const activity = createActivity({
+        closedBy: botUser,
+        reviews: [createReview(reviewer)],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count ubiquity-os-beta closed issues as collaborative", () => {
+      const activity = createActivity({
+        closedBy: botBeta,
+        reviews: [createReview(reviewer)],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count github-actions[bot] closed issues as collaborative", () => {
+      const activity = createActivity({
+        closedBy: ghActionsBot,
+        reviews: [createReview(reviewer)],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("counts human-closed issues as collaborative", () => {
+      const activity = createActivity({
+        closedBy: humanCollaborator,
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+  });
+
+  describe("bot label exclusion", () => {
+    it("does not count bot-applied pricing labels as collaboration", () => {
+      const activity = createActivity({
+        closedBy: author,
+        events: [{ event: "labeled", actor: botUser, label: { name: "Time: <1 Day" } }],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("counts human-applied pricing labels as collaboration", () => {
+      const activity = createActivity({
+        closedBy: author,
+        events: [{ event: "labeled", actor: humanCollaborator, label: { name: "Time: <1 Day" } }],
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+  });
+
+  describe("assignee exclusion", () => {
+    it("does not count assignee-applied pricing labels as collaboration", () => {
+      const activity = createActivity({
+        closedBy: author,
+        assignees: [assignee],
+        events: [{ event: "labeled", actor: assignee, label: { name: "Time: <1 Day" } }],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count assignee assignment events as collaboration", () => {
+      const activity = createActivity({
+        closedBy: author,
+        assignees: [assignee],
+        events: [{ event: "assigned", actor: assignee }],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("counts non-assignee assignment events as collaboration", () => {
+      const activity = createActivity({
+        closedBy: author,
+        assignees: [assignee],
+        events: [{ event: "assigned", actor: humanCollaborator }],
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Bounty
Fixes #455 | Reward: $150

## Problem
The `isCollaborative()` function had several gaps that allowed self-reward without genuine human oversight:

1. **Bot-closed issues counted as collaborative** — When `ubiquity-os`, `ubiquity-os-beta`, or `github-actions[bot]` closed an issue, it was treated as human collaboration
2. **Bot-applied labels counted as collaboration** — Automated pricing labels (Time/Priority) from bot accounts were counted as human involvement
3. **Assignee actions counted as external oversight** — When assignees set their own pricing labels or assigned themselves, it was treated as collaboration

## Changes

### `src/helpers/checkers.ts`
- **Add bot detection**: Added `BOT_LOGIN_PATTERNS` list and `isBotAccount()` helper to identify known bot accounts (`ubiquity-os`, `ubiquity-os-beta`, `github-actions[bot]`, `dependabot[bot]`, `vercel[bot]`, and any `[bot]` suffix)
- **Bot-closed issues return false**: If the closer is a bot, `isCollaborative()` returns `false` immediately
- **Bot label exclusion**: Bot-applied Time/Priority labels no longer count as human collaboration
- **Assignee exclusion**: Added `assigneeIds` set to exclude assignees from pricing label and assignment event checks
- **Assignment event checking**: Added check for `assigned` events by non-assignee, non-bot actors

### `tests/helpers/checkers.test.ts`
Added 9 new test cases across 3 new describe blocks:
- **Bot detection** (4 tests): Verify bot-closed issues are not collaborative, human-closed are
- **Bot label exclusion** (2 tests): Verify bot-applied labels don't count, human-applied do
- **Assignee exclusion** (3 tests): Verify assignee labels/assignments don't count, non-assignee assignments do

## Test Results
```
Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total (8 existing + 9 new)
```

## ETH Wallet
`0xB7729D3927d507E4f1687B6f462F1eA3c654C8Fe`