### PR TITLE
fix: require human collaboration before reward generation

### DIFF
--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -7,21 +7,30 @@ type ReviewAuthorAssociation = NonNullable<GitHubPullRequestReviewState["author_
 
 const COLLABORATOR_REVIEW_ASSOCIATIONS: ReviewAuthorAssociation[] = ["COLLABORATOR", "MEMBER", "OWNER"];
 
+function isHumanUser(user: { type?: string | null } | null | undefined) {
+  return user?.type !== "Bot";
+}
+
 export function isCollaborative(data: Readonly<IssueActivity>) {
   if (!data.self?.closed_by || !data.self.user) return false;
   const issueCreator = data.self.user;
 
-  if (data.self.closed_by.id === issueCreator.id) {
+  if (isHumanUser(data.self.closed_by) && data.self.closed_by.id !== issueCreator.id) {
+    return true;
+  }
+
+  if (data.self.closed_by.id === issueCreator.id || !isHumanUser(data.self.closed_by)) {
     const pricingEventsByNonAssignee = data.events.find(
       (event) =>
         event.event === "labeled" &&
         "label" in event &&
         (event.label.name.startsWith("Time: ") || event.label.name.startsWith("Priority: ")) &&
-        event.actor.id !== issueCreator.id
+        event.actor.id !== issueCreator.id &&
+        isHumanUser(event.actor)
     );
     return !!pricingEventsByNonAssignee || !!nonAssigneeApprovedReviews(data);
   }
-  return true;
+  return false;
 }
 
 export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {
@@ -57,6 +66,7 @@ function hasApprovedReviewByCollaborator(
   return reviews.some(
     (review) =>
       Boolean(review.user?.id) &&
+      isHumanUser(review.user) &&
       !excludedUserIds.has(String(review.user?.id)) &&
       review.state === "APPROVED" &&
       isReviewByCollaborator(review)
@@ -75,6 +85,7 @@ function hasIssueContextApprovedReview(
   return reviews.some(
     (review) =>
       Boolean(review.user?.id) &&
+      isHumanUser(review.user) &&
       review.user?.id !== assigneeId &&
       review.state === "APPROVED" &&
       !isReviewRequestedForUser(pullRequest, review)

--- a/tests/helpers/checkers.test.ts
+++ b/tests/helpers/checkers.test.ts
@@ -5,6 +5,7 @@ import type { IssueActivity } from "../../src/issue-activity";
 type User = {
   id: number;
   login: string;
+  type?: string;
 };
 
 const author = { id: 1, login: "author" };
@@ -12,6 +13,7 @@ const assignee = { id: 2, login: "assignee" };
 const reviewer = { id: 3, login: "reviewer" };
 const issueAuthor = { id: 4, login: "issue-author" };
 const outsideReviewer = { id: 5, login: "outside-reviewer" };
+const bot = { id: 6, login: "github-actions[bot]", type: "Bot" };
 
 function createReview(
   user: User,
@@ -27,25 +29,29 @@ function createReview(
 
 function createActivity({
   pullRequestContext = false,
+  closedBy = author,
   issueAssignee,
   linkedIssueAuthor,
+  events = [],
   reviews = [],
   requestedReviewers = [],
 }: {
   pullRequestContext?: boolean;
+  closedBy?: User;
   issueAssignee?: User;
   linkedIssueAuthor?: User;
+  events?: unknown[];
   reviews?: GitHubPullRequestReviewState[];
   requestedReviewers?: User[];
 }) {
   return {
     self: {
       user: author,
-      closed_by: author,
+      closed_by: closedBy,
       assignee: issueAssignee,
       pull_request: pullRequestContext ? { html_url: "https://github.com/owner/repo/pull/1" } : undefined,
     },
-    events: [],
+    events,
     linkedMergedPullRequests: [
       {
         self: {
@@ -68,6 +74,73 @@ function createActivity({
 }
 
 describe("collaboration checks", () => {
+  describe("isCollaborative", () => {
+    it("treats a different human closer as collaborative", () => {
+      const activity = createActivity({
+        closedBy: reviewer,
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("does not treat bot closure as human collaboration", () => {
+      const activity = createActivity({
+        closedBy: bot,
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("allows bot closure when there is separate human collaboration", () => {
+      const activity = createActivity({
+        closedBy: bot,
+        events: [
+          {
+            actor: reviewer,
+            event: "labeled",
+            label: {
+              name: "Time: <2 Hours",
+            },
+          },
+        ],
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("does not count bot-added pricing labels as human collaboration", () => {
+      const activity = createActivity({
+        events: [
+          {
+            actor: bot,
+            event: "labeled",
+            label: {
+              name: "Time: <2 Hours",
+            },
+          },
+        ],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("counts human-added pricing labels as collaboration", () => {
+      const activity = createActivity({
+        events: [
+          {
+            actor: reviewer,
+            event: "labeled",
+            label: {
+              name: "Priority: 2 (Medium)",
+            },
+          },
+        ],
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+  });
+
   describe("nonAssigneeApprovedReviews", () => {
     it("uses PR reviews when the reward context is a pull request without assignees", () => {
       const activity = createActivity({
@@ -93,6 +166,16 @@ describe("collaboration checks", () => {
       const activity = createActivity({
         pullRequestContext: true,
         reviews: [createReview(reviewer, "APPROVED", "CONTRIBUTOR"), createReview(outsideReviewer, "APPROVED", "NONE")],
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count bot approvals in pull request context", () => {
+      const activity = createActivity({
+        pullRequestContext: true,
+        reviews: [createReview(bot)],
       });
 
       expect(nonAssigneeApprovedReviews(activity)).toBe(false);


### PR DESCRIPTION
Fixes #455

Supersedes #553, which became stuck on an old head SHA after it was auto-closed and the branch was force-pushed.

This tightens the collaboration gate so reward generation does not count bot-only involvement as sufficient human review.

Changes:
- Ignore bot closures as a collaboration signal instead of short-circuiting other valid human collaboration paths.
- Reject bot-added pricing labels as collaboration.
- Reject bot approvals as collaboration.
- Preserve existing valid human collaboration paths.

Verification:
- npx jest tests/helpers/checkers.test.ts --runInBand
- npx eslint src/helpers/checkers.ts tests/helpers/checkers.test.ts