### PR TITLE
Refine generic comment relevance scoring

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -628,12 +628,17 @@ export class ContentEvaluatorModule extends BaseModule {
         - Relation to the issue description
         - Connection to other comments
         - Contribution to issue resolution
+        - Whether the comment contains issue-specific substance, not just a generic development activity
       5. Handle GitHub-flavored markdown:
         - Ignore text beginning with '>' as it references another comment
         - Distinguish between referenced text and the commenter's own words
         - Only evaluate the relevance of the commenter's original content
-      6. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
-      7. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
+      6. Penalize generic or weakly related comments:
+        - Score near 0 when a comment only mentions broad work such as "add tests", "fix it", "looks good", "refactor", or process chatter without explaining how it solves this issue.
+        - Do not infer relevance from the comment author, assignee, repository, or prior activity.
+        - A comment is relevant only when its own original content ties directly to the issue's requirements, bug, acceptance criteria, or a concrete resolution path.
+      7. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
+      8. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
 
       Notes:
       - Even minor details may be significant.

--- a/tests/content-evaluator-prompt.test.ts
+++ b/tests/content-evaluator-prompt.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "@jest/globals";
+import { ContentEvaluatorModule } from "../src/parser/content-evaluator-module";
+
+describe("ContentEvaluatorModule prompt generation", () => {
+  it("instructs the model to downscore generic test-only issue comments", () => {
+    const module = Object.create(ContentEvaluatorModule.prototype) as ContentEvaluatorModule;
+
+    const prompt = module._generatePromptForComments("Improve relevance scoring for issue comments.", "contributor", [
+      {
+        id: 1,
+        author: "contributor",
+        comment: "I will add tests for this.",
+      },
+      {
+        id: 2,
+        author: "maintainer",
+        comment: "The evaluator is over-rewarding generic comments.",
+      },
+    ]);
+
+    expect(prompt).toContain("Score near 0 when a comment only mentions broad work such as");
+    expect(prompt).toContain("\"add tests\"");
+    expect(prompt).toContain("Do not infer relevance from the comment author, assignee, repository, or prior activity.");
+    expect(prompt).toContain("A comment is relevant only when its own original content ties directly to the issue");
+  });
+});


### PR DESCRIPTION
Resolves #223

## Summary

- Tighten the issue-comment relevance prompt so generic development comments such as "add tests" are scored near zero unless they explain how they solve the issue.
- Tell the evaluator not to infer relevance from author, assignee, repository, or prior activity.
- Add a focused prompt-generation test for the regression case.

## Verification

- `npx jest tests/content-evaluator-prompt.test.ts --runInBand`
- `npx tsc --noEmit`

Notes: local verification used `npm install --legacy-peer-deps --ignore-scripts --package-lock=false` because Bun is not installed on this machine. The repo expects Node `>=24.11.1`; this machine has Node `22.14.0`, but the focused test and TypeScript check both passed after generating ignored `src/types/rpcs.json`.
