### PR TITLE
fix: ignore multiline slash commands in comment rewards

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -49,14 +49,18 @@ export class DataPurgeModule extends BaseModule {
     return false;
   }
 
+  private _removeSlashCommandBlocks(body: string): string {
+    const lines = body.split(/\r?\n/);
+    const commandIndex = lines.findIndex((line) => /^\s*\/\S/.test(line));
+    return commandIndex === -1 ? body : lines.slice(0, commandIndex).join("\n");
+  }
+
   private _cleanCommentBody(body: string): string {
-    const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+    const urlRegex = /(?<!\]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
     return (
-      body
+      this._removeSlashCommandBlocks(body)
         // Remove quoted text
         .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, it, jest } from "@jest/globals";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import "./helpers/permit-mock";
 import { drop } from "@mswjs/data";
 import { Logs } from "@ubiquity-os/ubiquity-os-logger";
@@ -121,5 +121,20 @@ describe("Purging tests", () => {
     await processor.run(activity);
     const result = JSON.parse(processor.dump());
     expect(result).toEqual(hiddenCommentPurged);
+  });
+
+  it("Should remove multiline slash commands and their content", () => {
+    const dataPurgeModule = new DataPurgeModule(ctx) as unknown as {
+      _cleanCommentBody(body: string): string;
+    };
+
+    expect(dataPurgeModule._cleanCommentBody("/ask\n\nWill this be counted?\nIt should not be.")).toHaveLength(0);
+    expect(dataPurgeModule._cleanCommentBody("/start\n\nI am starting this task")).toHaveLength(0);
+    expect(dataPurgeModule._cleanCommentBody("Useful context before command.\n/ask\nIgnore this content.")).toBe(
+      "Useful context before command."
+    );
+    expect(dataPurgeModule._cleanCommentBody("Regular comment mentioning /ask inline.")).toBe(
+      "Regular comment mentioning /ask inline."
+    );
   });
 });


### PR DESCRIPTION
## Summary
- strip slash-command blocks before reward comment evaluation
- handle multiline command payloads for `/ask` and `/start`
- preserve useful text before commands and inline slash mentions

## Verification
- `bun x prettier --check src/parser/data-purge-module.ts tests/purging.test.ts`
- `bun x eslint src/parser/data-purge-module.ts tests/purging.test.ts`
- `bun x jest tests/purging.test.ts --runInBand`
- `bun run build`
- `bun run jest:test --runInBand`

Closes #242