### PR TITLE
Refine relevance scoring prompt

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -22,6 +22,9 @@ import { ContextPlugin } from "../types/plugin-input";
 import { LINKED_ISSUES, PullRequestClosingIssue } from "../types/requests";
 import { GithubCommentScore, Result } from "../types/results";
 
+export const OFF_TOPIC_SCORING_META_DISCUSSION_GUIDANCE =
+  "Treat reward, payment, bot, or relevance-scoring meta-discussion as off-topic unless it directly proposes a concrete implementation or specification change for the current issue.";
+
 function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
   return (
     typeof value === "object" &&
@@ -628,6 +631,7 @@ export class ContentEvaluatorModule extends BaseModule {
         - Relation to the issue description
         - Connection to other comments
         - Contribution to issue resolution
+        - ${OFF_TOPIC_SCORING_META_DISCUSSION_GUIDANCE}
       5. Handle GitHub-flavored markdown:
         - Ignore text beginning with '>' as it references another comment
         - Distinguish between referenced text and the commenter's own words
@@ -662,6 +666,7 @@ export class ContentEvaluatorModule extends BaseModule {
     - 1.0: Strongly advances a fix/feature tied to one or more specifications, or significantly improves correctness, safety, performance, or maintainability in direct relation to the specs.
     - 0.5: Somewhat helpful or partially relevant; raises a valid concern or improvement but limited in scope/impact.
     - 0.0: Not relevant, incorrect, or off-topic with respect to the specifications; noise.
+    - ${OFF_TOPIC_SCORING_META_DISCUSSION_GUIDANCE}
 
     Additional notes:
     - Some comments are code-review entries and include a "diffHunk" representing the code context under review.

--- a/tests/content-evaluator-prompt.test.ts
+++ b/tests/content-evaluator-prompt.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  ContentEvaluatorModule,
+  OFF_TOPIC_SCORING_META_DISCUSSION_GUIDANCE,
+} from "../src/parser/content-evaluator-module";
+
+describe("Content evaluator prompt", () => {
+  const evaluator = Object.create(ContentEvaluatorModule.prototype) as ContentEvaluatorModule;
+
+  it("guides issue comment scoring to downscore scoring meta-discussion", () => {
+    const prompt = evaluator._generatePromptForComments("Implement vector search improvements.", "gentlementlegen", [
+      {
+        id: 1,
+        author: "0x4007",
+        comment: "Relevance scoring could have done so much better here for you @gentlementlegen",
+      },
+      {
+        id: 2,
+        author: "gentlementlegen",
+        comment:
+          "> Relevance scoring could have done so much better here for you @gentlementlegen\n\nPerhaps this conversation should be saved as a unit test so that we can improve the relevance scoring prompt.",
+      },
+    ]);
+
+    expect(prompt).toContain(OFF_TOPIC_SCORING_META_DISCUSSION_GUIDANCE);
+    expect(prompt).toContain("2 - gentlementlegen");
+    expect(prompt).toContain('"2": <score>');
+  });
+
+  it("guides pull request comment scoring to downscore scoring meta-discussion", () => {
+    const prompt = evaluator._generatePromptForPrComments("Implement vector search improvements.", [
+      {
+        id: 3,
+        comment: "The reward scoring should have paid this contributor more.",
+      },
+    ]);
+
+    expect(prompt).toContain(OFF_TOPIC_SCORING_META_DISCUSSION_GUIDANCE);
+    expect(prompt).toContain('"3": <score>');
+  });
+});


### PR DESCRIPTION
## Summary
- Add explicit guidance to score reward/payment/bot/relevance-scoring meta-discussion as off-topic unless it proposes a concrete current-issue implementation or specification change.
- Apply the guidance to both issue-comment and PR-comment relevance prompts.
- Add prompt regression coverage using the reported relevance-scoring conversation pattern.

## Validation
- Prettier check passed for changed files.
- Focused prompt test passed.
- ESLint passed for changed files.
- TypeScript check passed after generating the ignored RPC data used by the existing project setup.

Resolves #223

EVM payout address: 0xE7201960FEa5bFF7Ae4Fe3286093dCedabeDB003