### PR TITLE
[codex] Clarify missing token contract errors

### DIFF
--- a/src/parser/github-comment-module.ts
+++ b/src/parser/github-comment-module.ts
@@ -77,9 +77,35 @@ export class GithubCommentModule extends BaseModule {
       return cached;
     }
     const tokenContract = await getContract(config.evmNetworkId, config.erc20RewardToken, ERC20_ABI);
-    const symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    const symbol = await this._fetchTokenSymbol(new Erc20Wrapper(tokenContract), config);
     this._tokenSymbolCache.set(key, symbol);
     return symbol;
+  }
+
+  private async _fetchTokenSymbol(tokenContract: Erc20Wrapper, config: RewardSettings) {
+    try {
+      return await tokenContract.getSymbol();
+    } catch (e) {
+      if (!this._isTokenLookupError(e)) {
+        throw e;
+      }
+      throw new Error(`This token ${config.erc20RewardToken} was not found on network ID ${config.evmNetworkId}`);
+    }
+  }
+
+  private _isTokenLookupError(e: unknown): boolean {
+    if (typeof e !== "object" || e === null) {
+      return false;
+    }
+    const error = e as { code?: unknown; error?: unknown; message?: unknown; reason?: unknown };
+    const message = typeof error.message === "string" ? error.message.toLowerCase() : "";
+    const reason = typeof error.reason === "string" ? error.reason.toLowerCase() : "";
+    return (
+      error.code === "CALL_EXCEPTION" ||
+      message.includes("call revert exception") ||
+      reason.includes("call revert exception") ||
+      (error.error !== e && this._isTokenLookupError(error.error))
+    );
   }
 
   private async _getTokenDisplayForUser(username: string) {

--- a/tests/github-comment-token-symbol.test.ts
+++ b/tests/github-comment-token-symbol.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { IssueActivity } from "../src/issue-activity";
+import { ContextPlugin } from "../src/types/plugin-input";
+import { Result } from "../src/types/results";
+import cfg from "./__mocks__/results/valid-configuration.json";
+import { mockWeb3Module } from "./helpers/web3-mocks";
+
+const issueUrl = "https://github.com/ubiquity/work.ubq.fi/issues/69";
+const wxdaiAddress = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
+const web3Mocks = mockWeb3Module();
+
+jest.mock("@actions/github", () => ({
+  default: {},
+  context: {
+    runId: "1",
+    payload: {
+      repository: {
+        html_url: "https://github.com/ubiquity-os/conversation-rewards",
+      },
+    },
+    sha: "1234",
+  },
+}));
+
+describe("GithubCommentModule token symbol lookup", () => {
+  let githubCommentModule: InstanceType<typeof import("../src/parser/github-comment-module").GithubCommentModule>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const { GithubCommentModule } = await import("../src/parser/github-comment-module");
+    githubCommentModule = new GithubCommentModule({
+      eventName: "issues.closed",
+      payload: {
+        issue: {
+          html_url: issueUrl,
+          number: 69,
+          state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+          ],
+        },
+        repository: {
+          name: "conversation-rewards",
+          owner: {
+            login: "ubiquity-os",
+            id: 76412717,
+          },
+        },
+      },
+      config: {
+        ...cfg,
+        rewards: {
+          ...cfg.rewards,
+          erc20RewardToken: wxdaiAddress,
+          evmNetworkId: 1,
+        },
+      },
+    } as unknown as ContextPlugin);
+  });
+
+  it("throws a clear error when the reward token contract is missing on the configured network", async () => {
+    const tokenLookupError = Object.assign(new Error("call revert exception"), { code: "CALL_EXCEPTION" });
+    web3Mocks.Erc20Wrapper.getSymbol.mockImplementationOnce(() => Promise.reject(tokenLookupError));
+
+    const result: Result = {
+      gentlementlegen: {
+        total: 10,
+        userId: 123,
+        permitUrl: "https://pay.ubq.fi",
+        payoutMode: "permit",
+        walletAddress: "0x1",
+        evaluationCommentHtml: "<p>None</p>",
+      },
+    };
+
+    await expect(githubCommentModule.getBodyContent({} as unknown as IssueActivity, result)).rejects.toThrow(
+      `This token ${wxdaiAddress} was not found on network ID 1`
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- catch ERC20 token symbol lookup call exceptions in `GithubCommentModule`
- replace the raw ethers missing-contract error with a message that includes the reward token address and configured network ID
- add a regression test for a reward token configured on the wrong network

Fixes #271

## Validation
- `npx jest tests/github-comment-token-symbol.test.ts tests/fees.test.ts tests/github-comment-simplification-rounding.test.ts --runInBand`
- `npx tsc --noEmit` after generating `src/types/rpcs.json`, which this repo's Bun prepare step normally creates