### PR TITLE
fix: check all linked pull request approvals

### DIFF
--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -25,25 +25,30 @@ export function isCollaborative(data: Readonly<IssueActivity>) {
 }
 
 export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {
-  const linkedPullRequest = data.linkedMergedPullRequests[0];
-  if (!linkedPullRequest) {
+  if (!data.linkedMergedPullRequests.length) {
     return false;
   }
 
   if (data.self?.pull_request) {
-    const pullRequestAuthorId = linkedPullRequest.self?.user?.id ?? data.self.user?.id;
-    const excludedAuthorIds = new Set(
-      [pullRequestAuthorId, ...data.linkedIssues.map((issue) => issue.node.author?.id)].filter(Boolean).map(String)
-    );
-    return hasApprovedReviewByCollaborator(linkedPullRequest.reviews, excludedAuthorIds);
+    const selfUserId = data.self.user?.id;
+    return data.linkedMergedPullRequests.some((linkedPullRequest) => {
+      const pullRequestAuthorId = linkedPullRequest.self?.user?.id ?? selfUserId;
+      const excludedAuthorIds = new Set(
+        [pullRequestAuthorId, ...data.linkedIssues.map((issue) => issue.node.author?.id)].filter(Boolean).map(String)
+      );
+      return hasApprovedReviewByCollaborator(linkedPullRequest.reviews, excludedAuthorIds);
+    });
   }
 
   const assigneeId = data.self?.assignee?.id;
-  if (!assigneeId || !linkedPullRequest.self) {
+  if (!assigneeId) {
     return false;
   }
 
-  return hasIssueContextApprovedReview(linkedPullRequest.self, linkedPullRequest.reviews, assigneeId);
+  return data.linkedMergedPullRequests.some(
+    (linkedPullRequest) =>
+      linkedPullRequest.self && hasIssueContextApprovedReview(linkedPullRequest.self, linkedPullRequest.reviews, assigneeId)
+  );
 }
 
 function hasApprovedReviewByCollaborator(

--- a/tests/helpers/checkers.test.ts
+++ b/tests/helpers/checkers.test.ts
@@ -120,6 +120,32 @@ describe("collaboration checks", () => {
       expect(isCollaborative(activity)).toBe(false);
     });
 
+
+    it("uses approvals from later linked merged pull requests", () => {
+      const activity = createActivity({
+        pullRequestContext: true,
+      });
+      (activity as IssueActivity).linkedMergedPullRequests = [
+        {
+          self: {
+            user: author,
+            requested_reviewers: [],
+          },
+          reviews: [],
+        },
+        {
+          self: {
+            user: author,
+            requested_reviewers: [],
+          },
+          reviews: [createReview(reviewer)],
+        },
+      ];
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(true);
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
     it("does not treat an empty PR review list as collaborative", () => {
       const activity = createActivity({
         pullRequestContext: true,


### PR DESCRIPTION
Closes #455

## Summary
- checks every linked merged pull request for qualifying collaborator approval instead of only index 0
- keeps PR-context exclusions for PR author and linked issue authors
- keeps issue-context assignee behavior while allowing approval on later linked PRs
- adds regression coverage for approval present only on a later linked merged PR

## Verification
- `npx jest --runTestsByPath tests/helpers/checkers.test.ts --runInBand`
- `npx eslint src/helpers/checkers.ts tests/helpers/checkers.test.ts`

Note: local install required `npm install --legacy-peer-deps --ignore-scripts` because this environment has Node v22.22.2 while package engines request Node >=24.11.1 and prepare expects `bun`.