### PR TITLE
fix: purge multiline slash commands

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -51,12 +51,13 @@ export class DataPurgeModule extends BaseModule {
 
   private _cleanCommentBody(body: string): string {
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+    if (body.trimStart().startsWith("/")) {
+      return "";
+    }
     return (
       body
         // Remove quoted text
         .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -122,4 +122,10 @@ describe("Purging tests", () => {
     const result = JSON.parse(processor.dump());
     expect(result).toEqual(hiddenCommentPurged);
   });
+
+  it("Should purge multiline slash commands", () => {
+    const module = new DataPurgeModule(ctx);
+    expect(module["_cleanCommentBody"]("/ask\nplease summarize this issue")).toBe("");
+    expect(module["_cleanCommentBody"]("   /finish\nclosing note")).toBe("");
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/242

## Summary

- Treat comments that start with a slash command as command-only content during data purge.
- Prevent multiline command payloads, such as `/ask` prompts, from being evaluated as normal conversation comments.
- Add coverage for multiline slash command purging.

## Verification

- `bun x jest tests/purging.test.ts --runInBand --verbose --silent=false`
- `bun x prettier --check src/parser/data-purge-module.ts tests/purging.test.ts`
- `bun x jest tests/process.issue.test.ts --runInBand --silent`
