### PR TITLE
fix: refine relevance scoring prompt

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -628,12 +628,15 @@ export class ContentEvaluatorModule extends BaseModule {
         - Relation to the issue description
         - Connection to other comments
         - Contribution to issue resolution
+        - Whether the commenter's own words contain actionable analysis, evidence, implementation details, or a decision that materially advances the task
       5. Handle GitHub-flavored markdown:
         - Ignore text beginning with '>' as it references another comment
         - Distinguish between referenced text and the commenter's own words
         - Only evaluate the relevance of the commenter's original content
-      6. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
-      7. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
+      6. Score comments low (0 to 0.2) when the commenter's own words are mostly meta discussion, reward/result commentary, generic agreement, uncertainty, status chatter, or social remarks, even if the comment quotes relevant text, mentions an active contributor, or appears near relevant comments in the thread.
+      7. Do not award high relevance just because a comment is long, is from a frequent contributor, or participates in a relevant thread; the comment itself must help resolve the issue.
+      8. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
+      9. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
 
       Notes:
       - Even minor details may be significant.

--- a/tests/parser/content-evaluator-module.test.ts
+++ b/tests/parser/content-evaluator-module.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { ContentEvaluatorModule } from "../../src/parser/content-evaluator-module";
+import { ContextPlugin } from "../../src/types/plugin-input";
+
+const context = {
+  config: {
+    incentives: {
+      contentEvaluator: {
+        openAi: {
+          tokenCountLimit: 124000,
+          maxRetries: 10,
+        },
+        multipliers: [],
+      },
+    },
+  },
+  logger: {
+    warn: jest.fn(),
+  },
+} as unknown as ContextPlugin;
+
+describe("ContentEvaluatorModule", () => {
+  describe("_generatePromptForComments", () => {
+    it("instructs the model to score non-actionable meta reward comments low", () => {
+      const module = new ContentEvaluatorModule(context);
+      const prompt = module._generatePromptForComments(
+        "Fix duplicated matching comments on label events.",
+        "gentlementlegen",
+        [
+          {
+            id: 1,
+            author: "0x4007",
+            comment: "The matcher posts another comment every time a label event fires.",
+          },
+          {
+            id: 2,
+            author: "gentlementlegen",
+            comment:
+              "> Relevance scoring could have done so much better here for you\n\nLooks like it did the right thing for your reward.",
+          },
+        ]
+      );
+
+      expect(prompt).toContain("Score comments low (0 to 0.2)");
+      expect(prompt).toContain("reward/result commentary");
+      expect(prompt).toContain("Do not award high relevance just because a comment is long");
+      expect(prompt).toContain("Their comment IDs are: 2");
+    });
+  });
+});


### PR DESCRIPTION
Resolves #223

## Summary

- Tightened the issue-comment relevance prompt so meta discussion, reward/result commentary, generic agreement, uncertainty, and social chatter score low when the commenter's own words do not advance the task.
- Added a regression test for the cited `gentlementlegen`-style reward-comment case to keep the prompt guidance in place.

## Testing

- `npx jest tests\parser\content-evaluator-module.test.ts --runInBand`
- `npx eslint src\parser\content-evaluator-module.ts tests\parser\content-evaluator-module.test.ts`
- `npx prettier --check src\parser\content-evaluator-module.ts tests\parser\content-evaluator-module.test.ts`

Note: `npx tsc --noEmit` is currently blocked in this local environment because `src/types/rpcs.json` is generated by the Bun prepare step, and Bun is not installed here.