### PR TITLE
fix: validate reward generation behavior - block self-reward without collaboration

### DIFF
--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -11,17 +11,36 @@ export function isCollaborative(data: Readonly<IssueActivity>) {
   if (!data.self?.closed_by || !data.self.user) return false;
   const issueCreator = data.self.user;
 
-  if (data.self.closed_by.id === issueCreator.id) {
-    const pricingEventsByNonAssignee = data.events.find(
-      (event) =>
-        event.event === "labeled" &&
-        "label" in event &&
-        (event.label.name.startsWith("Time: ") || event.label.name.startsWith("Priority: ")) &&
-        event.actor.id !== issueCreator.id
-    );
-    return !!pricingEventsByNonAssignee || !!nonAssigneeApprovedReviews(data);
-  }
-  return true;
+  // Check if closed_by is a different human user (not a bot)
+  const closedByDifferentHuman =
+    data.self.closed_by.id !== issueCreator.id && data.self.closed_by.type === "User";
+
+  // Check if pricing labels were set by someone other than the issue creator
+  const pricingEventsByNonAssignee = data.events.find(
+    (event) =>
+      event.event === "labeled" &&
+      "label" in event &&
+      (event.label.name.startsWith("Time: ") || event.label.name.startsWith("Priority: ")) &&
+      event.actor.id !== issueCreator.id
+  );
+
+  // Check if the issue was assigned by someone other than the assignee
+  const assigneeId = data.self.assignee?.id;
+  const assignedByDifferentHuman = assigneeId
+    ? data.events.some(
+        (event) =>
+          event.event === "assigned" &&
+          event.actor.id !== assigneeId &&
+          event.actor.type === "User"
+      )
+    : false;
+
+  return (
+    closedByDifferentHuman ||
+    !!pricingEventsByNonAssignee ||
+    !!assignedByDifferentHuman ||
+    !!nonAssigneeApprovedReviews(data)
+  );
 }
 
 export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {

--- a/tests/helpers/checkers.test.ts
+++ b/tests/helpers/checkers.test.ts
@@ -5,13 +5,16 @@ import type { IssueActivity } from "../../src/issue-activity";
 type User = {
   id: number;
   login: string;
+  type: string;
 };
 
-const author = { id: 1, login: "author" };
-const assignee = { id: 2, login: "assignee" };
-const reviewer = { id: 3, login: "reviewer" };
-const issueAuthor = { id: 4, login: "issue-author" };
-const outsideReviewer = { id: 5, login: "outside-reviewer" };
+const author = { id: 1, login: "author", type: "User" };
+const assignee = { id: 2, login: "assignee", type: "User" };
+const reviewer = { id: 3, login: "reviewer", type: "User" };
+const issueAuthor = { id: 4, login: "issue-author", type: "User" };
+const outsideReviewer = { id: 5, login: "outside-reviewer", type: "User" };
+const bot = { id: 99, login: "bot[bot]", type: "Bot" };
+const otherHuman = { id: 100, login: "other-human", type: "User" };
 
 function createReview(
   user: User,
@@ -25,27 +28,33 @@ function createReview(
   } as GitHubPullRequestReviewState;
 }
 
+type ActivityOptions = {
+  pullRequestContext?: boolean;
+  issueAssignee?: User;
+  linkedIssueAuthor?: User;
+  reviews?: GitHubPullRequestReviewState[];
+  requestedReviewers?: User[];
+  closedBy?: User;
+  events?: Array<{ event: string; actor: User; label?: { name: string } }>;
+};
+
 function createActivity({
   pullRequestContext = false,
   issueAssignee,
   linkedIssueAuthor,
   reviews = [],
   requestedReviewers = [],
-}: {
-  pullRequestContext?: boolean;
-  issueAssignee?: User;
-  linkedIssueAuthor?: User;
-  reviews?: GitHubPullRequestReviewState[];
-  requestedReviewers?: User[];
-}) {
+  closedBy,
+  events = [],
+}: ActivityOptions) {
   return {
     self: {
       user: author,
-      closed_by: author,
+      closed_by: closedBy ?? author,
       assignee: issueAssignee,
       pull_request: pullRequestContext ? { html_url: "https://github.com/owner/repo/pull/1" } : undefined,
     },
-    events: [],
+    events,
     linkedMergedPullRequests: [
       {
         self: {
@@ -146,6 +155,100 @@ describe("collaboration checks", () => {
 
       expect(nonAssigneeApprovedReviews(activity)).toBe(false);
       expect(isCollaborative(activity)).toBe(false);
+    });
+  });
+
+  describe("isCollaborative - bot closed_by should not count as collaboration", () => {
+    it("does not count bot closing the issue as collaborative", () => {
+      const activity = createActivity({
+        closedBy: bot,
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("counts a different human closing the issue as collaborative", () => {
+      const activity = createActivity({
+        closedBy: otherHuman,
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("counts same-author closing as non-collaborative when no other signals", () => {
+      const activity = createActivity({
+        closedBy: author,
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+  });
+
+  describe("isCollaborative - assignment by different human", () => {
+    it("counts assignment by a different human as collaborative", () => {
+      const activity = createActivity({
+        issueAssignee: assignee,
+        events: [{ event: "assigned", actor: otherHuman }],
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("does not count self-assignment as collaborative", () => {
+      const activity = createActivity({
+        issueAssignee: assignee,
+        events: [{ event: "assigned", actor: assignee }],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count bot assignment as collaborative", () => {
+      const activity = createActivity({
+        issueAssignee: assignee,
+        events: [{ event: "assigned", actor: bot }],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("counts assignment by author (different from assignee) as collaborative", () => {
+      const activity = createActivity({
+        issueAssignee: assignee,
+        events: [{ event: "assigned", actor: author }],
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+  });
+
+  describe("isCollaborative - combined signals", () => {
+    it("counts pricing labels by non-assignee as collaborative even when closed by same author", () => {
+      const activity = createActivity({
+        closedBy: author,
+        events: [{ event: "labeled", actor: otherHuman, label: { name: "Time: 1h" } }],
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("is not collaborative when all actions are by the same user with no reviews", () => {
+      const activity = createActivity({
+        closedBy: author,
+        events: [{ event: "assigned", actor: author }],
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("is collaborative when bot closes but human reviewed", () => {
+      const activity = createActivity({
+        closedBy: bot,
+        issueAssignee: assignee,
+        reviews: [createReview(reviewer)],
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #455

### Problem
The reward generation system was allowing users to receive rewards even when no other human collaborator was involved in the task lifecycle. For example, a user could create an issue, self-assign, create a PR, and merge it (possibly via a bot), receiving the full reward without any other human participating.

### Root Cause
The `isCollaborative()` function in `src/helpers/checkers.ts` had two issues:
1. **Bot `closed_by` counted as collaboration**: If a bot closed the issue (which is different from the issue creator), the function returned `true` (collaborative), even though no human was involved.
2. **Missing assignment check**: The function didn't check if someone other than the assignee had assigned the issue.

### Changes

#### `src/helpers/checkers.ts`
- **Bot accounts no longer count**: `closed_by` must now be a human user (`type === "User"`) to be considered collaborative.
- **Added assignment event check**: If the issue was assigned by a human other than the assignee itself, it's now considered collaborative.
- **Preserved existing checks**: Pricing label events by non-assignee and non-assignee approved reviews still count as collaboration signals.

#### `tests/helpers/checkers.test.ts`
- Added `type` property to all test user objects for realistic mocking.
- Added 10 new test cases:
  - Bot closing issue does not count as collaborative
  - Different human closing counts as collaborative
  - Assignment by different human counts as collaborative
  - Self-assignment does not count
  - Bot assignment does not count
  - Combined signal tests

### Testing
All 18 tests pass (8 existing + 10 new).