### PR TITLE
Fix multiline slash command purging

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -49,14 +49,27 @@ export class DataPurgeModule extends BaseModule {
     return false;
   }
 
+  private _removeCommandBlocks(body: string): string {
+    const commandLineRegex = /^[^\S\r\n]*\/[a-z][\w-]*(?:[^\S\r\n]+.*)?$/i;
+    const filteredLines: string[] = [];
+
+    for (const line of body.split(/\r?\n/)) {
+      if (commandLineRegex.test(line)) {
+        break;
+      }
+
+      filteredLines.push(line);
+    }
+
+    return filteredLines.join("\n");
+  }
+
   private _cleanCommentBody(body: string): string {
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
     return (
-      body
+      this._removeCommandBlocks(body)
         // Remove quoted text
         .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -98,6 +98,8 @@ afterAll(() => server.close());
 describe("Purging tests", () => {
   const issue = parseGitHubUrl(issueUrl);
   let activity: IssueActivity;
+  const cleanCommentBody = (body: string) =>
+    (new DataPurgeModule(ctx) as unknown as { _cleanCommentBody(body: string): string })._cleanCommentBody(body);
 
   beforeEach(async () => {
     drop(db);
@@ -121,5 +123,25 @@ describe("Purging tests", () => {
     await processor.run(activity);
     const result = JSON.parse(processor.dump());
     expect(result).toEqual(hiddenCommentPurged);
+  });
+
+  it("Should purge multiline slash command content", () => {
+    const result = cleanCommentBody("/ask\nPlease check my scoring.\nThis should not be evaluated.");
+
+    expect(result).toBe("");
+  });
+
+  it("Should keep non-command content before multiline slash commands", () => {
+    const result = cleanCommentBody(
+      "Useful context before the command.\n\n/ask\nPlease check my scoring.\n\nThis command body should not be evaluated."
+    );
+
+    expect(result).toBe("Useful context before the command.");
+  });
+
+  it("Should not purge slash-prefixed paths as commands", () => {
+    const result = cleanCommentBody("The route /api/rewards should keep working.");
+
+    expect(result).toBe("The route /api/rewards should keep working.");
   });
 });


### PR DESCRIPTION
Resolves #242

## Summary

- remove multiline slash command blocks before scoring comment content
- keep normal content that appears before a slash command
- avoid treating ordinary slash-prefixed paths as commands

## Verification

- node command block assertions
- prettier check
- git diff --check