### PR TITLE
Strip multiline slash commands from reward comments

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -49,14 +49,23 @@ export class DataPurgeModule extends BaseModule {
     return false;
   }
 
+  private _startsWithSlashCommand(body: string): boolean {
+    const firstContentLine = body.split(/\r?\n/).find((line) => line.trim().length > 0);
+    return firstContentLine?.trimStart().startsWith("/") ?? false;
+  }
+
   private _cleanCommentBody(body: string): string {
+    if (this._startsWithSlashCommand(body)) {
+      return "";
+    }
+
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
     return (
       body
         // Remove quoted text
         .replace(/^>.*$/gm, "")
         // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+        .replace(/^\/[^\r\n]*/gm, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -122,4 +122,19 @@ describe("Purging tests", () => {
     const result = JSON.parse(processor.dump());
     expect(result).toEqual(hiddenCommentPurged);
   });
+
+  it("Should purge multiline slash command comments", () => {
+    const dataPurgeModule = new DataPurgeModule(ctx) as unknown as { _cleanCommentBody(body: string): string };
+
+    expect(dataPurgeModule._cleanCommentBody("/ask\nPlease score this follow-up text.")).toBe("");
+    expect(dataPurgeModule._cleanCommentBody("\n  /ask\nPlease score this follow-up text.")).toBe("");
+  });
+
+  it("Should keep normal multiline comments while removing embedded command lines", () => {
+    const dataPurgeModule = new DataPurgeModule(ctx) as unknown as { _cleanCommentBody(body: string): string };
+
+    expect(dataPurgeModule._cleanCommentBody("Useful context\n/start\nMore context")).toBe(
+      "Useful context\n\nMore context"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Treat comments whose first content line is a slash command as command-only content so multiline `/ask` prompts are not scored as conversation comments.
- Make embedded one-line slash command removal multiline-aware.
- Add regression coverage for multiline command bodies and normal multiline comments.

## Validation
- `npx jest tests/purging.test.ts --runInBand` -> 3 passed

Fixes #242.

Implemented with OpenAI Codex assistance.