### PR TITLE
Show clear missing token contract error

### DIFF
--- a/src/parser/github-comment-module.ts
+++ b/src/parser/github-comment-module.ts
@@ -77,9 +77,43 @@ export class GithubCommentModule extends BaseModule {
       return cached;
     }
     const tokenContract = await getContract(config.evmNetworkId, config.erc20RewardToken, ERC20_ABI);
-    const symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    let symbol: string;
+    try {
+      symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    } catch (err) {
+      if (this._isMissingTokenSymbolError(err)) {
+        throw this.context.logger.error(
+          `This token ${config.erc20RewardToken} was not found on network ID ${config.evmNetworkId}.`,
+          {
+            err,
+            tokenAddress: config.erc20RewardToken,
+            networkId: config.evmNetworkId,
+          }
+        );
+      }
+      throw err;
+    }
     this._tokenSymbolCache.set(key, symbol);
     return symbol;
+  }
+
+  private _isMissingTokenSymbolError(err: unknown) {
+    const error = err as { code?: unknown; method?: unknown; data?: unknown; message?: unknown };
+    let message = "";
+    if (err instanceof Error) {
+      message = err.message;
+    } else if (typeof error.message === "string") {
+      message = error.message;
+    }
+    const code = typeof error.code === "string" ? error.code : "";
+    const method = typeof error.method === "string" ? error.method : "";
+    const data = typeof error.data === "string" ? error.data : "";
+
+    return (
+      (code === "CALL_EXCEPTION" || message.includes("CALL_EXCEPTION") || message.includes("call revert exception")) &&
+      (method === "symbol()" || message.includes('method="symbol()"')) &&
+      (data === "0x" || message.includes('data="0x"'))
+    );
   }
 
   private async _getTokenDisplayForUser(username: string) {

--- a/tests/github-comment-simplification-rounding.test.ts
+++ b/tests/github-comment-simplification-rounding.test.ts
@@ -7,7 +7,7 @@ import { mockWeb3Module } from "./helpers/web3-mocks";
 
 const issueUrl = "https://github.com/ubiquity/work.ubq.fi/issues/69";
 
-mockWeb3Module();
+const web3Mocks = mockWeb3Module();
 
 jest.mock("@actions/github", () => ({
   default: {},
@@ -24,8 +24,17 @@ jest.mock("@actions/github", () => ({
 
 describe("GithubCommentModule Simplification Rounding", () => {
   let githubCommentModule: InstanceType<typeof import("../src/parser/github-comment-module").GithubCommentModule>;
+  let logger: Record<string, unknown>;
 
   beforeEach(async () => {
+    web3Mocks.Erc20Wrapper.getSymbol.mockReset();
+    web3Mocks.Erc20Wrapper.getSymbol.mockReturnValue("WXDAI");
+    logger = {
+      error: jest.fn((raw: string, metadata?: unknown) => ({ logMessage: { raw }, metadata })),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
     const { GithubCommentModule } = await import("../src/parser/github-comment-module");
     githubCommentModule = new GithubCommentModule({
       eventName: "issues.closed",
@@ -50,6 +59,7 @@ describe("GithubCommentModule Simplification Rounding", () => {
         },
       },
       config: cfg,
+      logger,
     } as unknown as ContextPlugin);
   });
 
@@ -83,5 +93,35 @@ describe("GithubCommentModule Simplification Rounding", () => {
 
     expect(bodyContent.raw).toContain("<td>Task Simplification</td><td>1</td><td>1.44</td>");
     expect(bodyContent.raw).not.toContain("1.4400000000000002");
+  });
+
+  it("should describe missing token contracts when symbol lookup fails", async () => {
+    web3Mocks.Erc20Wrapper.getSymbol.mockRejectedValueOnce(
+      Object.assign(new Error('call revert exception (method="symbol()", data="0x", code=CALL_EXCEPTION)'), {
+        code: "CALL_EXCEPTION",
+        method: "symbol()",
+        data: "0x",
+      }) as never
+    );
+
+    const result: Result = {
+      gentlementlegen: {
+        total: 1,
+        userId: 123,
+        permitUrl: "https://pay.ubq.fi",
+        payoutMode: "permit",
+        walletAddress: "0x1",
+      },
+    };
+
+    await expect(githubCommentModule.getBodyContent({} as unknown as IssueActivity, result)).rejects.toMatchObject({
+      logMessage: {
+        raw: "This token 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d was not found on network ID 100.",
+      },
+      metadata: {
+        tokenAddress: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+        networkId: 100,
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- convert missing ERC20 symbol lookups into a clear token/network error
- include the token address and network id in the error metadata for debugging
- add a regression test for ethers `CALL_EXCEPTION` responses from `symbol()`

## Tests
- `npx eslint src\parser\github-comment-module.ts tests\github-comment-simplification-rounding.test.ts`
- `npx tsc --noEmit --moduleResolution bundler --module ESNext --target ESNext --esModuleInterop --strict --skipLibCheck --resolveJsonModule src\parser\github-comment-module.ts tests\github-comment-simplification-rounding.test.ts`
- `npx jest tests\github-comment-simplification-rounding.test.ts --runInBand`
- `git diff --check`

Fixes #271