### PR TITLE
fix: clarify missing token contract errors

### DIFF
--- a/src/parser/github-comment-module.ts
+++ b/src/parser/github-comment-module.ts
@@ -33,6 +33,32 @@ interface BodyComment {
   raw: string;
 }
 
+interface ContractCallError {
+  code?: string;
+  method?: string;
+  message?: string;
+}
+
+function isTokenSymbolCallException(error: unknown) {
+  const callError = error as ContractCallError;
+  const message = callError.message;
+  return (
+    callError.code === "CALL_EXCEPTION" ||
+    callError.method === "symbol()" ||
+    (typeof message === "string" && message.includes("call revert exception") && message.includes("symbol()"))
+  );
+}
+
+export function createTokenSymbolLookupError(error: unknown, config: RewardSettings) {
+  if (!isTokenSymbolCallException(error)) {
+    return error;
+  }
+  return new Error(
+    `Token ${config.erc20RewardToken} was not found on network ID ${config.evmNetworkId}. ` +
+      "The smart contract does not exist on this network."
+  );
+}
+
 /**
  * Posts a GitHub comment according to the given results.
  */
@@ -77,7 +103,12 @@ export class GithubCommentModule extends BaseModule {
       return cached;
     }
     const tokenContract = await getContract(config.evmNetworkId, config.erc20RewardToken, ERC20_ABI);
-    const symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    let symbol: string;
+    try {
+      symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    } catch (error) {
+      throw createTokenSymbolLookupError(error, config);
+    }
     this._tokenSymbolCache.set(key, symbol);
     return symbol;
   }

--- a/tests/github-comment-token-symbol.test.ts
+++ b/tests/github-comment-token-symbol.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "@jest/globals";
+import { createTokenSymbolLookupError } from "../src/parser/github-comment-module";
+import type { RewardSettings } from "../src/types/plugin-input";
+
+const rewardSettings: RewardSettings = {
+  evmNetworkId: 1,
+  evmPrivateEncrypted: "encrypted-key",
+  erc20RewardToken: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+};
+
+describe("createTokenSymbolLookupError", () => {
+  it("explains token and network when symbol lookup reverts", () => {
+    const error = Object.assign(new Error('call revert exception (method="symbol()")'), {
+      code: "CALL_EXCEPTION",
+      method: "symbol()",
+    });
+
+    expect(createTokenSymbolLookupError(error, rewardSettings)).toEqual(
+      new Error(
+        "Token 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d was not found on network ID 1. " +
+          "The smart contract does not exist on this network."
+      )
+    );
+  });
+
+  it("preserves unrelated lookup errors", () => {
+    const error = new Error("RPC endpoint unavailable");
+
+    expect(createTokenSymbolLookupError(error, rewardSettings)).toBe(error);
+  });
+});


### PR DESCRIPTION
Resolves #271

## Summary
- Convert token symbol lookup CALL_EXCEPTION failures into a clear token/network configuration error.
- Preserve unrelated token lookup errors so they still surface normally.
- Add focused coverage for the missing-token-contract path and unrelated-error passthrough.

## Verification
- npx jest tests/github-comment-token-symbol.test.ts --runInBand
- npx prettier --check src/parser/github-comment-module.ts tests/github-comment-token-symbol.test.ts
- npx eslint src/parser/github-comment-module.ts tests/github-comment-token-symbol.test.ts
- npx cspell src/parser/github-comment-module.ts tests/github-comment-token-symbol.test.ts
- npx tsc --noEmit --pretty false

Note: I also ran npx jest tests/rewards.test.ts --runInBand locally on Windows; 5/7 tests passed and the two failures were output.html fixture line-ending equality differences.