### PR TITLE
fix: explain missing reward token contract

### DIFF
--- a/src/parser/github-comment-module.ts
+++ b/src/parser/github-comment-module.ts
@@ -77,7 +77,15 @@ export class GithubCommentModule extends BaseModule {
       return cached;
     }
     const tokenContract = await getContract(config.evmNetworkId, config.erc20RewardToken, ERC20_ABI);
-    const symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    let symbol: string;
+    try {
+      symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    } catch (error) {
+      throw this.context.logger.error(
+        `Reward token ${config.erc20RewardToken} does not appear to exist on network ID ${config.evmNetworkId}, or it does not implement symbol(). Verify the token address and configured network ID.`,
+        { error: error instanceof Error ? error : new Error(String(error)) }
+      );
+    }
     this._tokenSymbolCache.set(key, symbol);
     return symbol;
   }

--- a/tests/github-comment-token-symbol-error.test.ts
+++ b/tests/github-comment-token-symbol-error.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { ContextPlugin } from "../src/types/plugin-input";
+import cfg from "./__mocks__/results/valid-configuration.json";
+import { mockWeb3Module } from "./helpers/web3-mocks";
+
+const web3Mocks = mockWeb3Module();
+
+jest.mock("@actions/github", () => ({
+  default: {},
+  context: {
+    runId: "1",
+    payload: {
+      repository: {
+        html_url: "https://github.com/ubiquity-os/conversation-rewards",
+      },
+    },
+    sha: "1234",
+  },
+}));
+
+describe("GithubCommentModule token symbol errors", () => {
+  let githubCommentModule: InstanceType<typeof import("../src/parser/github-comment-module").GithubCommentModule>;
+  const logger = {
+    error: jest.fn((message: string, _context?: unknown) => new Error(message)),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const { GithubCommentModule } = await import("../src/parser/github-comment-module");
+    githubCommentModule = new GithubCommentModule({
+      eventName: "issues.closed",
+      payload: {
+        issue: {
+          html_url: "https://github.com/ubiquity/work.ubq.fi/issues/271",
+          number: 271,
+          state_reason: "completed",
+        },
+        repository: {
+          name: "conversation-rewards",
+          owner: {
+            login: "ubiquity-os",
+            id: 76412717,
+          },
+        },
+      },
+      config: cfg,
+      logger,
+    } as unknown as ContextPlugin);
+  });
+
+  it("should explain when the configured reward token is missing on the configured network", async () => {
+    web3Mocks.Erc20Wrapper.getSymbol.mockImplementationOnce(async () => {
+      throw new Error("CALL_EXCEPTION: missing revert data");
+    });
+
+    await expect(
+      (githubCommentModule as unknown as { _getTokenDisplayForUser(username: string): Promise<unknown> })._getTokenDisplayForUser("0x4007")
+    ).rejects.toThrow("does not appear to exist on network ID 100");
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("Verify the token address and configured network ID."),
+      expect.objectContaining({ error: expect.any(Error) })
+    );
+  });
+});


### PR DESCRIPTION
Resolves #271

Summary:
- Catch token symbol lookup failures from ERC20 contracts.
- Replace cryptic CALL_EXCEPTION failures with a clear token/network configuration error.
- Added regression coverage for missing reward token contract errors.

Validation:
- ESLint passed for changed files.
- TypeScript check shows no errors in changed files.
