### PR TITLE
fix: ignore multiline slash command payloads

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -51,12 +51,16 @@ export class DataPurgeModule extends BaseModule {
 
   private _cleanCommentBody(body: string): string {
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+    const bodyWithoutQuotedText = body.replace(/^>.*$/gm, "");
+
+    if (/^[ \t\r\n]*\/\S+[\s\S]*$/.test(bodyWithoutQuotedText)) {
+      return "";
+    }
+
     return (
-      body
-        // Remove quoted text
-        .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+      bodyWithoutQuotedText
+        // Remove commands such as /start from comments that also contain regular text
+        .replace(/^\/\S+.*(?:\r?\n)?/gm, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -122,4 +122,31 @@ describe("Purging tests", () => {
     const result = JSON.parse(processor.dump());
     expect(result).toEqual(hiddenCommentPurged);
   });
+
+  it("Should drop multiline slash-command comments", () => {
+    const dataPurgeModule = new DataPurgeModule(ctx) as unknown as {
+      _cleanCommentBody(body: string): string;
+    };
+
+    const cleanedBody = dataPurgeModule._cleanCommentBody(`/ask
+Please check my scoring.
+
+This content belongs to the command and should not be evaluated.`);
+
+    expect(cleanedBody).toBe("");
+  });
+
+  it("Should keep regular text when removing an embedded slash command line", () => {
+    const dataPurgeModule = new DataPurgeModule(ctx) as unknown as {
+      _cleanCommentBody(body: string): string;
+    };
+
+    const cleanedBody = dataPurgeModule._cleanCommentBody(`This is a regular comment.
+/start
+This part should stay because the whole comment is not a command payload.`);
+
+    expect(cleanedBody).toBe(
+      "This is a regular comment.\nThis part should stay because the whole comment is not a command payload."
+    );
+  });
 });


### PR DESCRIPTION
## Issue
Closes ubiquity-os-marketplace/text-conversation-rewards#242.

## Summary
- skips comments that are slash-command payloads before reward evaluation
- keeps ordinary comments evaluable while removing embedded command-only lines
- adds purge tests for multiline commands and mixed regular text

## Verification
- `git diff --check`
- `node --check src/parser/data-purge-module.ts`
- `bun x jest tests/purging.test.ts --runInBand`

## Bounty / payout
Bounty issue: ubiquity-os-marketplace/text-conversation-rewards#242
Preferred payout: PayPal https://paypal.me/Jeremytsangchina
Backup: USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y