### PR TITLE
fix: refine relevance prompt for meta comments

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -628,19 +628,24 @@ export class ContentEvaluatorModule extends BaseModule {
         - Relation to the issue description
         - Connection to other comments
         - Contribution to issue resolution
-      5. Handle GitHub-flavored markdown:
+        - Whether the comment directly advances the issue rather than only discussing the reward bot, scoring bot, automation behavior, or unrelated process metadata
+      5. Score process/meta comments conservatively:
+        - Comments about bots being broken, reward scoring, who received rewards, assignment mechanics, or the evaluator itself should receive a low score unless they give concrete information needed to solve the current issue.
+        - Generic coordination, praise, complaints, or observations that do not add a test case, reproduction detail, implementation detail, or decision for the current issue should be near 0.
+        - A comment can be well written and still receive a low relevance score if it does not help resolve the issue description.
+      6. Handle GitHub-flavored markdown:
         - Ignore text beginning with '>' as it references another comment
         - Distinguish between referenced text and the commenter's own words
         - Only evaluate the relevance of the commenter's original content
-      6. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
-      7. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
+      7. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
+      8. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
 
       Notes:
       - Even minor details may be significant.
       - Comments may reference earlier comments.
       - The number of entries in the JSON response MUST equal ${targetComments.length}.
 
-      Example Output Format (for format only — not content): {${targetComments.map((o) => `"${o.id}": <score>`).join(", ")}}
+      Example Output Format (for format only - not content): {${targetComments.map((o) => `"${o.id}": <score>`).join(", ")}}
 
       YOUR RESPONSE MUST CONTAIN ONLY THE RAW JSON OBJECT WITH NO FORMATTING, NO EXPLANATION, NO BACKTICKS, NO CODE BLOCKS.
     `;
@@ -675,7 +680,7 @@ export class ContentEvaluatorModule extends BaseModule {
 
     Reply with ONLY a raw JSON object mapping each comment ID to a float between 0 and 1.
     The number of entries in the JSON response MUST equal ${userComments.length}.
-    Example Output Format (for format only — not content): {${userComments.map((o) => `"${o.id}": <score>`).join(", ")}}
+    Example Output Format (for format only - not content): {${userComments.map((o) => `"${o.id}": <score>`).join(", ")}}
     Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
 
     YOUR RESPONSE MUST CONTAIN ONLY THE RAW JSON OBJECT WITH NO FORMATTING, NO EXPLANATION, NO BACKTICKS, NO CODE BLOCKS.`;

--- a/tests/content-evaluator-prompt.test.ts
+++ b/tests/content-evaluator-prompt.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "@jest/globals";
+import cfg from "./__mocks__/results/valid-configuration.json";
+import { ContentEvaluatorModule } from "../src/parser/content-evaluator-module";
+import { ContextPlugin } from "../src/types/plugin-input";
+
+const ctx = {
+  config: cfg,
+} as unknown as ContextPlugin;
+
+describe("Content evaluator prompt", () => {
+  it("guides the model to score reward-bot meta comments low", () => {
+    const module = new ContentEvaluatorModule(ctx);
+    const prompt = module._generatePromptForComments(
+      "Fix reward generation so only task-relevant implementation comments are paid.",
+      "gentlementlegen",
+      [
+        {
+          id: 100,
+          author: "gentlementlegen",
+          comment: "Okay both bots are broken @gentlementlegen. We should have specialized prompts.",
+        },
+        {
+          id: 101,
+          author: "maintainer",
+          comment: "Please add a regression test for irrelevant process comments.",
+        },
+      ]
+    );
+
+    expect(prompt).toContain("reward bot");
+    expect(prompt).toContain("scoring bot");
+    expect(prompt).toContain("should receive a low score");
+    expect(prompt).toContain("can be well written and still receive a low relevance score");
+  });
+});


### PR DESCRIPTION
## Issue
- Closes #223

## Summary
- Refined the issue-comment relevance prompt to score reward-bot/scoring-bot/process-meta comments conservatively when they do not directly advance the issue.
- Added a focused prompt regression test using the kind of gentlementlegen meta comment called out in the bounty.

## Verification
- `bun install --ignore-scripts`
- `bun x jest tests/content-evaluator-prompt.test.ts --runInBand`
- `bun x eslint src/parser/content-evaluator-module.ts tests/content-evaluator-prompt.test.ts`
- Generated `src/types/rpcs.json` locally and ran `bun x tsc --noEmit --pretty false`
- Changed-file whitespace check passed

## Bounty / payout
- Bounty issue: #223
- Preferred payout: PayPal https://paypal.me/Jeremytsangchina
- Backup payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`