### PR TITLE
Fix multiline slash command purge

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -51,12 +51,16 @@ export class DataPurgeModule extends BaseModule {
 
   private _cleanCommentBody(body: string): string {
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+    const bodyWithoutQuotedText = body.replace(/^>.*$/gm, "");
+
+    if (bodyWithoutQuotedText.trimStart().startsWith("/")) {
+      return "";
+    }
+
     return (
-      body
-        // Remove quoted text
-        .replace(/^>.*$/gm, "")
+      bodyWithoutQuotedText
         // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+        .replace(/^\/.+/gm, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/parser/data-purge-module.test.ts
+++ b/tests/parser/data-purge-module.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { DataPurgeModule } from "../../src/parser/data-purge-module";
+import { ContextPlugin } from "../../src/types/plugin-input";
+
+const ctx = {
+  config: {
+    incentives: {
+      dataPurge: {
+        skipCommentsWhileAssigned: "none",
+      },
+    },
+  },
+  logger: new Logs("debug"),
+  payload: {
+    issue: {
+      html_url: "https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/242",
+    },
+  },
+} as unknown as ContextPlugin;
+
+describe("DataPurgeModule", () => {
+  const module = new DataPurgeModule(ctx) as unknown as {
+    _cleanCommentBody(body: string): string;
+  };
+
+  it("removes multiline slash commands from rewardable comment content", () => {
+    const empty = String();
+    const body = [
+      "/ask",
+      "Can you check my scoring?",
+      empty,
+      "This text belongs to the slash command and should not be evaluated.",
+    ].join("\n");
+
+    expect(module._cleanCommentBody(body)).toBe(empty);
+  });
+});


### PR DESCRIPTION
Resolves #242

## Summary
- Treat comments whose cleaned content starts with a slash command as non-rewardable command output.
- Preserve the existing single-line slash command cleanup for mixed comments.
- Add a regression test for multiline slash command content.

## Verification
- TMPDIR=/tmp PATH=/tmp/node-v24.11.1-linux-x64/bin:$PATH /tmp/node-v24.11.1-linux-x64/bin/node ./node_modules/jest/bin/jest.js tests/purging.test.ts tests/parser/data-purge-module.test.ts --runInBand --coverage=false
- TMPDIR=/tmp PATH=/tmp/node-v24.11.1-linux-x64/bin:$PATH /tmp/node-v24.11.1-linux-x64/bin/node ./node_modules/eslint/bin/eslint.js src/parser/data-purge-module.ts tests/parser/data-purge-module.test.ts
- TMPDIR=/tmp PATH=/tmp/node-v24.11.1-linux-x64/bin:$PATH /tmp/node-v24.11.1-linux-x64/bin/node ./node_modules/prettier/bin/prettier.cjs --check src/parser/data-purge-module.ts tests/parser/data-purge-module.test.ts
- TMPDIR=/tmp PATH=/tmp/node-v24.11.1-linux-x64/bin:$PATH /tmp/node-v24.11.1-linux-x64/bin/node ./node_modules/cspell/bin.mjs src/parser/data-purge-module.ts tests/parser/data-purge-module.test.ts
- git diff --check -- src/parser/data-purge-module.ts tests/parser/data-purge-module.test.ts