### PR TITLE
Prefund permit wallets with faucet

### DIFF
--- a/src/configuration/payment-configuration.ts
+++ b/src/configuration/payment-configuration.ts
@@ -1,5 +1,7 @@
 import { Static, Type } from "@sinclair/typebox";
 
+export const DEFAULT_FAUCET_URL = "https://ubq-faucet.workers.dev/";
+
 export const paymentConfigurationType = Type.Object(
   {
     /**
@@ -12,6 +14,13 @@ export const paymentConfigurationType = Type.Object(
         default: true,
         description:
           "If set to false, or if there are insufficient funds to settle the payment, permits will be generated instead of immediately transferring rewards to the beneficiaries.",
+      })
+    ),
+    faucetUrl: Type.Optional(
+      Type.String({
+        default: DEFAULT_FAUCET_URL,
+        description:
+          "Faucet endpoint used to prefund beneficiary wallets with native gas after generating claim permits.",
       })
     ),
   },

--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -19,7 +19,11 @@ import { randomUUID } from "crypto";
 import Decimal from "decimal.js";
 import { BigNumber, ethers, utils } from "ethers";
 import type { Database } from "../adapters/supabase/types/database";
-import { PaymentConfiguration, paymentConfigurationType } from "../configuration/payment-configuration";
+import {
+  DEFAULT_FAUCET_URL,
+  PaymentConfiguration,
+  paymentConfigurationType,
+} from "../configuration/payment-configuration";
 import { isAdmin, isCollaborative } from "../helpers/checkers";
 import { getUserRewardRole } from "../helpers/permissions";
 import { isGlobalRewardSettings, resolveRewardSettingsForRole, rewardConfigKey } from "../helpers/reward-settings";
@@ -306,6 +310,7 @@ export class PaymentModule extends BaseModule {
 
         result[username].permitUrl = `https://pay.ubq.fi?claim=${encodePermits(permits)}`;
         result[username].payoutMode = "permit";
+        await this._prefundWalletWithFaucet(username, reward.walletAddress);
         await this._savePermitsToDatabase(result[username], { issueUrl: payload.issueUrl, issueId }, permits);
       }
     }
@@ -636,6 +641,34 @@ export class PaymentModule extends BaseModule {
     };
 
     return result;
+  }
+
+  async _prefundWalletWithFaucet(username: string, walletAddress?: string) {
+    if (!walletAddress) {
+      return;
+    }
+
+    const faucetUrl = this._configuration?.faucetUrl ?? DEFAULT_FAUCET_URL;
+    const url = new URL(faucetUrl);
+    url.searchParams.set("address", walletAddress);
+
+    try {
+      const response = await fetch(url, { method: "POST" });
+      if (!response.ok) {
+        this.context.logger.warn("Faucet prefund request was not accepted.", {
+          username,
+          walletAddress,
+          status: response.status,
+          response: await response.text(),
+        });
+      }
+    } catch (e) {
+      this.context.logger.warn("Faucet prefund request failed.", {
+        username,
+        walletAddress,
+        err: e,
+      });
+    }
   }
 
   async _getOrCreateToken(address: string, network: number) {

--- a/tests/parser/payment-module.test.ts
+++ b/tests/parser/payment-module.test.ts
@@ -355,6 +355,39 @@ describe("payment-module.ts", () => {
     });
   });
 
+  describe("_prefundWalletWithFaucet()", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+      ctx.config.incentives.payment = null;
+    });
+
+    it("Should call the configured faucet with the wallet address", async () => {
+      ctx.config.incentives.payment = {
+        faucetUrl: "https://faucet.example/",
+      };
+      const fetchMock = jest.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+      jest.spyOn(global, "fetch").mockImplementation(fetchMock);
+
+      const paymentModule = new PaymentModule(ctx);
+      await paymentModule._prefundWalletWithFaucet("gentlementlegen", "0x123");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url.toString()).toBe("https://faucet.example/?address=0x123");
+      expect(options).toEqual({ method: "POST" });
+    });
+
+    it("Should not call the faucet without a wallet address", async () => {
+      const fetchMock = jest.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+      jest.spyOn(global, "fetch").mockImplementation(fetchMock);
+
+      const paymentModule = new PaymentModule(ctx);
+      await paymentModule._prefundWalletWithFaucet("gentlementlegen");
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe("_automaticTransferMode", () => {
     beforeEach(() => {
       ctx.env.PERMIT_FEE_RATE = EMPTY_STRING;


### PR DESCRIPTION
Resolves ubiquity/ubiquibot#893

## Summary
- add a configurable payment faucet URL with the existing Ubiquity faucet as default
- call the faucet after permit generation for each beneficiary wallet
- keep faucet errors non-blocking so permit generation and persistence still complete
- add unit coverage for the faucet helper

## QA
- git diff --check passed locally
- Jest was not run locally because this Windows environment does not have bun installed and the clone has no node_modules