### PR TITLE
fix: purge multiline slash commands

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -55,8 +55,8 @@ export class DataPurgeModule extends BaseModule {
       body
         // Remove quoted text
         .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+        // Remove slash command blocks so follow-up text is not scored as a normal comment
+        .replace(/^\/[\s\S]*/gm, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -112,6 +112,15 @@ describe("Purging tests", () => {
     await activity.init();
   });
 
+  it("Should purge multiline slash commands", () => {
+    const dataPurgeModule = new DataPurgeModule(ctx);
+    const cleanCommentBody = dataPurgeModule["_cleanCommentBody"].bind(dataPurgeModule);
+
+    expect(cleanCommentBody("/ask\n\nwhy did the score look off?")).toEqual("");
+    expect(cleanCommentBody("Please check this\n\n/ask\n\nwhy did the score look off?")).toEqual("Please check this");
+    expect(cleanCommentBody("/start\n\nI am starting this task")).toEqual("");
+  });
+
   it("Should purge collapsed comments", async () => {
     const { Processor } = await import("../src/parser/processor");
 


### PR DESCRIPTION
## Summary
- purge whole slash-command blocks instead of only the first `/command` line
- add a regression test for `/ask` and `/start` with multiline content

## Tests
- `bunx jest tests/purging.test.ts --runInBand`

Closes #242
