### PR TITLE
fix: refine relevance scoring for meta comments

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -628,12 +628,15 @@ export class ContentEvaluatorModule extends BaseModule {
         - Relation to the issue description
         - Connection to other comments
         - Contribution to issue resolution
+        - Whether the commenter's own words directly advance the requested work, not merely the reward discussion around it
       5. Handle GitHub-flavored markdown:
         - Ignore text beginning with '>' as it references another comment
         - Distinguish between referenced text and the commenter's own words
         - Only evaluate the relevance of the commenter's original content
-      6. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
-      7. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
+      6. Treat meta comments about rewards, relevance scoring, who should be paid, or whether another comment was scored correctly as low relevance unless the issue itself is specifically about rewards or relevance scoring.
+      7. Treat brief acknowledgements, thanks, status chatter, or social replies as low relevance unless they include a concrete bug report, solution, decision, or implementation detail tied to the issue.
+      8. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
+      9. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
 
       Notes:
       - Even minor details may be significant.

--- a/tests/content-evaluator-prompt.test.ts
+++ b/tests/content-evaluator-prompt.test.ts
@@ -1,0 +1,31 @@
+import { ContentEvaluatorModule } from "../src/parser/content-evaluator-module";
+import { ContextPlugin } from "../src/types/plugin-input";
+
+describe("ContentEvaluatorModule prompt generation", () => {
+  it("instructs the LLM to score reward meta discussion low unless it is on topic", () => {
+    const module = new ContentEvaluatorModule({
+      config: {
+        incentives: {
+          contentEvaluator: null,
+        },
+      },
+    } as unknown as ContextPlugin);
+
+    const prompt = module._generatePromptForComments("Fix issue matching for duplicate reports.", "gentlementlegen", [
+      {
+        id: 1,
+        author: "gentlementlegen",
+        comment: "Relevance scoring could have done so much better here.",
+      },
+      {
+        id: 2,
+        author: "maintainer",
+        comment: "Please focus on duplicate issue matching.",
+      },
+    ]);
+
+    expect(prompt).toContain("meta comments about rewards, relevance scoring, who should be paid");
+    expect(prompt).toContain("low relevance unless the issue itself is specifically about rewards or relevance scoring");
+    expect(prompt).toContain("brief acknowledgements, thanks, status chatter, or social replies as low relevance");
+  });
+});


### PR DESCRIPTION
Resolves #223

## Summary
- refine the issue-comment relevance prompt so reward/relevance meta discussion is scored low unless that is the issue topic
- add guidance for brief acknowledgements/status chatter to stay low unless they contain actionable issue details
- add a targeted prompt-generation test for the reported pattern

## Validation
- `npx jest tests/content-evaluator-prompt.test.ts --runInBand`
