### PR TITLE
fix: add specialized prompts for issue comment evaluation

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -31,6 +31,37 @@ function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
   );
 }
 
+type SpecializedEvaluationCriterion = {
+  key: string;
+  label: string;
+  weight: number;
+  instructions: string;
+};
+
+const ISSUE_COMMENT_EVALUATION_CRITERIA: SpecializedEvaluationCriterion[] = [
+  {
+    key: "taskSolving",
+    label: "Task solving relevance",
+    weight: 0.5,
+    instructions:
+      "Rate how directly the comment helps solve the issue specification through implementation details, bug analysis, reproducible evidence, or concrete progress.",
+  },
+  {
+    key: "contributorHelpfulness",
+    label: "Contributor helpfulness",
+    weight: 0.3,
+    instructions:
+      "Rate how much the comment helps contributors move forward by answering questions, clarifying requirements, unblocking implementation, or coordinating next steps.",
+  },
+  {
+    key: "researchInsight",
+    label: "Research and insight value",
+    weight: 0.2,
+    instructions:
+      "Rate whether the comment contributes useful research, external references, design tradeoffs, or technical insight that informs the project.",
+  },
+];
+
 /**
  * Evaluates and rates comments.
  */
@@ -328,7 +359,8 @@ export class ContentEvaluatorModule extends BaseModule {
     specification: string,
     username: string,
     comments: CommentToEvaluate[],
-    allComments: AllComments
+    allComments: AllComments,
+    criterion?: SpecializedEvaluationCriterion
   ) {
     const commentRelevances: Relevances = {};
     const evaluationCounts: Record<string, number> = {};
@@ -337,7 +369,13 @@ export class ContentEvaluatorModule extends BaseModule {
     let chunks = 0;
 
     for (let currentChunk = 2; currentChunk <= maxChunks; currentChunk++) {
-      const chunkTokenEstimates = this._getIssueChunkEstimates(specification, username, allComments, currentChunk);
+      const chunkTokenEstimates = this._getIssueChunkEstimates(
+        specification,
+        username,
+        allComments,
+        currentChunk,
+        criterion
+      );
       if (!chunkTokenEstimates.length) {
         continue;
       }
@@ -350,7 +388,7 @@ export class ContentEvaluatorModule extends BaseModule {
     }
 
     if (!chunks) {
-      const fallbackPrompt = this._generatePromptForComments(specification, username, allComments);
+      const fallbackPrompt = this._generatePromptForComments(specification, username, allComments, criterion);
       const dummyResponse = JSON.stringify(this._generateDummyResponse(comments), null, 2);
       const fallbackPromptTokens = this._calculateMaxTokens(fallbackPrompt, Infinity);
       const fallbackOutputTokens = this._calculateMaxTokens(dummyResponse);
@@ -372,7 +410,7 @@ export class ContentEvaluatorModule extends BaseModule {
       }
       const dummyResponse = JSON.stringify(this._generateDummyResponse(targetComments), null, 2);
       const maxOutputTokens = this._calculateMaxTokens(dummyResponse);
-      const promptForComments = this._generatePromptForComments(specification, username, commentSplit);
+      const promptForComments = this._generatePromptForComments(specification, username, commentSplit, criterion);
 
       for (const [key, value] of Object.entries(await this._submitPrompt(promptForComments, maxOutputTokens))) {
         const accumulated = commentRelevances[key] ?? 0;
@@ -393,7 +431,8 @@ export class ContentEvaluatorModule extends BaseModule {
     specification: string,
     username: string,
     allComments: AllComments,
-    chunks: number
+    chunks: number,
+    criterion?: SpecializedEvaluationCriterion
   ): { promptTokens: number; outputTokens: number }[] {
     return this._splitArrayToChunks(allComments, chunks)
       .map((chunk) => {
@@ -401,7 +440,7 @@ export class ContentEvaluatorModule extends BaseModule {
           return null;
         }
         const promptTokens = this._calculateMaxTokens(
-          this._generatePromptForComments(specification, username, chunk),
+          this._generatePromptForComments(specification, username, chunk, criterion),
           Infinity
         );
         const dummyResponse = JSON.stringify(
@@ -452,6 +491,60 @@ export class ContentEvaluatorModule extends BaseModule {
     return commentRelevances;
   }
 
+  async _evaluateIssueCommentsWithSpecializedPrompts(
+    specification: string,
+    username: string,
+    userIssueComments: CommentToEvaluate[],
+    allComments: AllComments
+  ): Promise<Relevances> {
+    const weightedRelevances: Relevances = {};
+    const totalWeight = ISSUE_COMMENT_EVALUATION_CRITERIA.reduce(
+      (acc, criterion) => acc.add(criterion.weight),
+      new Decimal(0)
+    );
+    const targetIds = userIssueComments.map((comment) => String(comment.id));
+
+    for (const criterion of ISSUE_COMMENT_EVALUATION_CRITERIA) {
+      const dummyResponse = JSON.stringify(this._generateDummyResponse(userIssueComments), null, 2);
+      const maxOutputTokens = this._calculateMaxTokens(dummyResponse);
+      const promptForIssueComments = this._generatePromptForComments(specification, username, allComments, criterion);
+      const criterionRelevances =
+        this._calculateMaxTokens(promptForIssueComments, Infinity) + maxOutputTokens > this._tokenLimit
+          ? await this._splitPromptForIssueCommentEvaluation(
+              specification,
+              username,
+              userIssueComments,
+              allComments,
+              criterion
+            )
+          : await this._submitPrompt(promptForIssueComments, maxOutputTokens);
+
+      for (const commentId of targetIds) {
+        if (criterionRelevances[commentId] === undefined) {
+          throw this.context.logger.error("There was a mismatch between specialized relevance scores and comments.", {
+            criterion: criterion.key,
+            commentId,
+            relevances: criterionRelevances,
+            comments: userIssueComments,
+          });
+        }
+        const accumulated = weightedRelevances[commentId] ?? 0;
+        weightedRelevances[commentId] = new Decimal(accumulated)
+          .add(new Decimal(criterionRelevances[commentId]).mul(criterion.weight))
+          .toNumber();
+      }
+    }
+
+    for (const commentId of targetIds) {
+      weightedRelevances[commentId] = new Decimal(weightedRelevances[commentId] ?? 0)
+        .div(totalWeight)
+        .toDecimalPlaces(4)
+        .toNumber();
+    }
+
+    return weightedRelevances;
+  }
+
   async _evaluateComments(
     specification: string,
     username: string,
@@ -463,20 +556,12 @@ export class ContentEvaluatorModule extends BaseModule {
     let prCommentRelevances: Relevances = {};
 
     if (userIssueComments.length && !this.isPullRequest()) {
-      const dummyResponse = JSON.stringify(this._generateDummyResponse(userIssueComments), null, 2);
-      const maxOutputTokens = this._calculateMaxTokens(dummyResponse);
-
-      const promptForIssueComments = this._generatePromptForComments(specification, username, allComments);
-      if (this._calculateMaxTokens(promptForIssueComments, Infinity) + maxOutputTokens > this._tokenLimit) {
-        commentRelevances = await this._splitPromptForIssueCommentEvaluation(
-          specification,
-          username,
-          userIssueComments,
-          allComments
-        );
-      } else {
-        commentRelevances = await this._submitPrompt(promptForIssueComments, maxOutputTokens);
-      }
+      commentRelevances = await this._evaluateIssueCommentsWithSpecializedPrompts(
+        specification,
+        username,
+        userIssueComments,
+        allComments
+      );
     }
 
     if (userPrComments.length && this.isPullRequest()) {
@@ -594,7 +679,12 @@ export class ContentEvaluatorModule extends BaseModule {
     }
   }
 
-  _generatePromptForComments(issue: string, username: string, allComments: AllComments) {
+  _generatePromptForComments(
+    issue: string,
+    username: string,
+    allComments: AllComments,
+    criterion?: SpecializedEvaluationCriterion
+  ) {
     if (!issue?.length) {
       throw new Error("Issue specification comment is missing or empty");
     }
@@ -607,11 +697,21 @@ export class ContentEvaluatorModule extends BaseModule {
       throw new Error(`No comments found for user ${username}`);
     }
     const targetCommentIds = targetComments.map((value) => value.id).join(", ");
+    const evaluationGoal = criterion
+      ? `Evaluate this specialized scoring dimension for GitHub comments authored by ${username}. Provide a raw JSON object with those comment IDs and their ${criterion.label.toLowerCase()} scores.
+
+      Criterion: ${criterion.label}
+      Final score weight: ${criterion.weight}
+      Criterion instructions: ${criterion.instructions}
+
+      Do not average this with other criteria. Return only this criterion's score for each target comment.`
+      : `Evaluate the relevance of GitHub comments to an issue. Focus exclusively on the comments authored by ${username}. Provide a raw JSON object with those comment IDs and their relevance scores.`;
+    const scoreName = criterion ? criterion.label.toLowerCase() : "relevance";
 
     return `
       CRITICAL REQUIREMENT: YOUR RESPONSE MUST BE RAW JSON ONLY - NO BACKTICKS, NO CODE BLOCKS, NO MARKDOWN.
       
-      Evaluate the relevance of GitHub comments to an issue. Focus exclusively on the comments authored by ${username}. Provide a raw JSON object with those comment IDs and their relevance scores.
+      ${evaluationGoal}
 
       Issue: ${issue}
 
@@ -621,7 +721,7 @@ export class ContentEvaluatorModule extends BaseModule {
       Instructions:
       1. Read all comments carefully, considering their context and content.
       2. Identify every comment authored by ${username}. Their comment IDs are: ${targetCommentIds}.
-      3. Assign a relevance score from 0 to 1 for each identified comment:
+      3. Assign a ${scoreName} score from 0 to 1 for each identified comment:
         - 0: Not related (e.g., spam)
         - 1: Highly relevant (e.g., solutions, bug reports)
       4. Consider:

--- a/tests/parser/content-evaluator-module-specialized.test.ts
+++ b/tests/parser/content-evaluator-module-specialized.test.ts
@@ -1,0 +1,79 @@
+import { jest } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { ContentEvaluatorModule } from "../../src/parser/content-evaluator-module";
+import { ContextPlugin } from "../../src/types/plugin-input";
+
+function createModule() {
+  const context = {
+    config: {
+      incentives: {
+        contentEvaluator: {
+          openAi: {
+            tokenCountLimit: 124000,
+            maxRetries: 1,
+            reasoningEffort: "low",
+          },
+          originalAuthorWeight: 0.5,
+          multipliers: [],
+        },
+        githubComment: {
+          post: false,
+        },
+      },
+    },
+    payload: {
+      issue: {
+        number: 1,
+      },
+      repository: {
+        owner: {
+          login: "ubiquity-os",
+        },
+        name: "conversation-rewards",
+      },
+    },
+    logger: new Logs("debug"),
+    commentHandler: {
+      postComment: jest.fn(),
+    },
+  } as unknown as ContextPlugin;
+
+  const module = new ContentEvaluatorModule(context);
+  Reflect.set(module, "_tokenLimit", 124000);
+  return module;
+}
+
+describe("ContentEvaluatorModule specialized issue comment evaluation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("combines specialized issue comment criteria using weighted scores", async () => {
+    const module = createModule();
+    const submitPrompt = jest
+      .spyOn(module, "_submitPrompt")
+      .mockResolvedValueOnce({ "101": 1, "102": 0 })
+      .mockResolvedValueOnce({ "101": 0, "102": 1 })
+      .mockResolvedValueOnce({ "101": 0.5, "102": 0.5 });
+
+    const result = await module._evaluateComments(
+      "Implement the requested feature and document the tradeoffs.",
+      "alice",
+      [
+        { id: 101, comment: "I implemented the core behavior and added tests." },
+        { id: 102, comment: "Here is background research and an answer to the API question." },
+      ],
+      [
+        { id: 101, author: "alice", comment: "I implemented the core behavior and added tests." },
+        { id: 102, author: "alice", comment: "Here is background research and an answer to the API question." },
+      ],
+      []
+    );
+
+    expect(result).toEqual({ "101": 0.6, "102": 0.4 });
+    expect(submitPrompt).toHaveBeenCalledTimes(3);
+    expect(submitPrompt.mock.calls[0][0]).toContain("Criterion: Task solving relevance");
+    expect(submitPrompt.mock.calls[1][0]).toContain("Criterion: Contributor helpfulness");
+    expect(submitPrompt.mock.calls[2][0]).toContain("Criterion: Research and insight value");
+  });
+});


### PR DESCRIPTION
﻿## Summary

Resolves #340.

Adds specialized issue-comment evaluation prompts for content relevance scoring. Issue comments are evaluated across three focused criteria:

- task solving relevance, weighted at 0.5
- contributor helpfulness, weighted at 0.3
- research and insight value, weighted at 0.2

The final score is combined from those criteria while preserving the existing reward calculation flow and retry/mismatch behavior. Chunked prompt evaluation also accepts the active specialized criterion so long conversations keep the same scoring semantics.

## Verification

- `npx jest tests/parser/content-evaluator-module-specialized.test.ts --runInBand`
- `npx prettier --check src/parser/content-evaluator-module.ts tests/parser/content-evaluator-module-specialized.test.ts`
- `npx eslint src/parser/content-evaluator-module.ts tests/parser/content-evaluator-module-specialized.test.ts`
- `npx bun run fetch-rpcs`
- `npx @ubiquity-os/plugin-manifest-tool@latest`
- `npx tsc --noEmit`