### PR TITLE
fix: clear rewards when payment is blocked

### DIFF
--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -93,7 +93,7 @@ export class PaymentModule extends BaseModule {
     const canMakePayment = await this._canMakePayment(data);
     if (!canMakePayment) {
       this.context.logger.warn("Non collaborative issue detected, skipping.");
-      return Promise.resolve(result);
+      return Promise.resolve(this._clearPayableRewards(result));
     }
 
     const { xpUsernames, tokenGroups } = await this._splitUsersByRewardConfiguration(result);
@@ -125,6 +125,31 @@ export class PaymentModule extends BaseModule {
     }
 
     return result;
+  }
+
+  private _clearPayableRewards(result: Result): Result {
+    for (const reward of Object.values(result)) {
+      this._clearNestedRewards(reward);
+      reward.total = 0;
+      delete reward.permitUrl;
+      delete reward.explorerUrl;
+      delete reward.payoutMode;
+    }
+    return result;
+  }
+
+  private _clearNestedRewards(value: unknown): void {
+    if (!value || typeof value !== "object") {
+      return;
+    }
+
+    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+      if (key === "reward" && typeof nestedValue === "number") {
+        (value as Record<string, unknown>)[key] = 0;
+      } else {
+        this._clearNestedRewards(nestedValue);
+      }
+    }
   }
 
   private _selectResultSubset(result: Result, usernames: string[]): Result {

--- a/tests/parser/payment-module.test.ts
+++ b/tests/parser/payment-module.test.ts
@@ -280,6 +280,55 @@ describe("payment-module.ts", () => {
     });
   });
 
+  describe("non-collaborative issues", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("clears payable rewards when payment is not allowed", async () => {
+      const paymentModule = new PaymentModule(ctx);
+      jest.spyOn(paymentModule, "_canMakePayment").mockResolvedValue(false);
+      const result: Result = {
+        contributor: {
+          total: 25,
+          userId: 1,
+          permitUrl: "https://pay.ubq.fi?claim=example",
+          explorerUrl: "https://gnosisscan.io/tx/0x1",
+          payoutMode: "permit",
+          task: {
+            reward: 15,
+            multiplier: 1,
+            timestamp: DEFAULT_TIMESTAMP,
+            url: DEFAULT_URL,
+          },
+          comments: [
+            {
+              id: 1,
+              content: "Helpful but not collaboratively approved.",
+              url: DEFAULT_URL,
+              timestamp: DEFAULT_TIMESTAMP,
+              commentType: CommentKind.ISSUE,
+              score: {
+                reward: 10,
+                multiplier: 1,
+                authorship: 1,
+              },
+            },
+          ],
+        },
+      };
+
+      const transformed = await paymentModule.transform({} as IssueActivity, result);
+
+      expect(transformed.contributor.total).toBe(0);
+      expect(transformed.contributor.task?.reward).toBe(0);
+      expect(transformed.contributor.comments?.[0].score?.reward).toBe(0);
+      expect(transformed.contributor.permitUrl).toBeUndefined();
+      expect(transformed.contributor.explorerUrl).toBeUndefined();
+      expect(transformed.contributor.payoutMode).toBeUndefined();
+    });
+  });
+
   describe("_savePermitsToDatabase()", () => {
     afterEach(() => {
       jest.restoreAllMocks();


### PR DESCRIPTION
﻿## Summary

Resolves #455.

Makes non-collaborative issue handling return a non-payable reward result instead of leaving calculated reward values in place after the payment gate fails.

When `_canMakePayment` is false, the payment module now:

- logs the existing non-collaborative issue warning
- clears nested numeric `reward` fields
- resets each user total to `0`
- removes payout metadata fields such as `permitUrl`, `explorerUrl`, and `payoutMode`

This keeps the returned result aligned with the skip-payment behavior and prevents the output from looking payable.

## Verification

- `npx jest tests/parser/payment-module.test.ts --runInBand`
- `npx jest tests/helpers/comment.test.ts tests/parser/data-purge-module.test.ts tests/fees.test.ts tests/parser/payment-module.test.ts tests/purging.test.ts --runInBand`
- `npx tsc --noEmit`
- `npx prettier --check src/parser/payment-module.ts tests/parser/payment-module.test.ts`
- `npx eslint src/parser/payment-module.ts tests/parser/payment-module.test.ts`