### PR TITLE
fix: preserve prior assignee research comments

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -1,4 +1,4 @@
-import { CommentAssociation } from "../configuration/comment-types";
+import { CommentAssociation, CommentKind } from "../configuration/comment-types";
 import { DataPurgeConfiguration } from "../configuration/data-purge-config";
 import { GitHubPullRequestReviewComment } from "../github-types";
 import { getAssignmentPeriods, isCommentDuringAssignment, UserAssignments } from "../helpers/user-assigned-timespan";
@@ -15,6 +15,7 @@ type CommentType = Awaited<ReturnType<IssueActivity["getAllComments"]>>[0];
 export class DataPurgeModule extends BaseModule {
   readonly _configuration: DataPurgeConfiguration | null = this.context.config.incentives.dataPurge;
   _assignmentPeriods: UserAssignments = {};
+  private _currentAssigneeLogins = new Set<string>();
 
   get enabled(): boolean {
     if (!this._configuration) {
@@ -40,6 +41,13 @@ export class DataPurgeModule extends BaseModule {
         this._configuration.skipCommentsWhileAssigned === "exact"
       )
     ) {
+      if (this._shouldKeepPreviousAssigneeResearchComment(comment, comment.user.login)) {
+        this.context.logger.debug("Keeping previous assignee issue comment for research credit", {
+          body: comment.body?.replace(/(.{100})..+/, "$1..."),
+          url: comment.html_url,
+        });
+        return false;
+      }
       this.context.logger.debug("Skipping comment during assignment", {
         body: comment.body?.replace(/(.{100})..+/, "$1…"),
         url: comment.html_url,
@@ -47,6 +55,14 @@ export class DataPurgeModule extends BaseModule {
       return true;
     }
     return false;
+  }
+
+  private _shouldKeepPreviousAssigneeResearchComment(
+    comment: Awaited<ReturnType<IssueActivity["getAllComments"]>>[0],
+    login: string
+  ) {
+    const isIssueComment = !!(comment.commentType & CommentKind.ISSUE);
+    return isIssueComment && !this._currentAssigneeLogins.has(login);
   }
 
   private _cleanCommentBody(body: string): string {
@@ -110,6 +126,7 @@ export class DataPurgeModule extends BaseModule {
         ? this.context.payload.pull_request.html_url
         : this.context.payload.issue.html_url;
     this._assignmentPeriods = await getAssignmentPeriods(this.context.octokit, parseGitHubUrl(htmlUrl));
+    this._currentAssigneeLogins = new Set((data.self?.assignees ?? []).map((assignee) => assignee.login));
     const allComments = await data.getAllComments(this.isPullRequest());
     for (const comment of allComments) {
       await this._processComment(comment, result);

--- a/tests/parser/data-purge-research-credit.test.ts
+++ b/tests/parser/data-purge-research-credit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { CommentKind } from "../../src/configuration/comment-types";
+import { DataPurgeModule } from "../../src/parser/data-purge-module";
+import { ContextPlugin } from "../../src/types/plugin-input";
+
+function createModule() {
+  const context = {
+    config: {
+      incentives: {
+        dataPurge: {
+          skipCommentsWhileAssigned: "all",
+        },
+      },
+    },
+    payload: {
+      issue: {
+        html_url: "https://github.com/ubiquity-os/conversation-rewards/issues/1",
+        assignees: [{ login: "current-assignee" }],
+      },
+      repository: {
+        owner: { login: "ubiquity-os" },
+        name: "conversation-rewards",
+      },
+    },
+    logger: new Logs("debug"),
+  } as unknown as ContextPlugin;
+
+  const module = new DataPurgeModule(context);
+  Reflect.set(module, "_assignmentPeriods", {
+    "previous-assignee": [{ assignedAt: "2025-03-01T00:00:00Z", unassignedAt: "2025-03-02T00:00:00Z" }],
+    "current-assignee": [{ assignedAt: "2025-03-01T00:00:00Z", unassignedAt: "2025-03-03T00:00:00Z" }],
+  });
+  Reflect.set(module, "_currentAssigneeLogins", new Set(["current-assignee"]));
+  return module;
+}
+
+function createAssignedComment(login: string, commentType: CommentKind) {
+  return {
+    body: "I researched the constraints and found a useful implementation path.",
+    commentType,
+    created_at: "2025-03-01T12:00:00Z",
+    html_url: `https://github.com/ubiquity-os/conversation-rewards/issues/1#${login}`,
+    user: { login },
+  } as never;
+}
+
+describe("DataPurgeModule research credit", () => {
+  it("keeps previous assignee issue comments but still skips current assignee and pull comments", async () => {
+    const module = createModule();
+
+    await expect(
+      module._shouldSkipComment(createAssignedComment("previous-assignee", CommentKind.ISSUE))
+    ).resolves.toBe(false);
+    await expect(module._shouldSkipComment(createAssignedComment("current-assignee", CommentKind.ISSUE))).resolves.toBe(
+      true
+    );
+    await expect(module._shouldSkipComment(createAssignedComment("previous-assignee", CommentKind.PULL))).resolves.toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
﻿## Summary

Resolves #296.

Allows previous assignees to receive issue-comment research credit while preserving the anti-gaming guard for the current assignee.

The data purge module now keeps an assigned-period comment only when it is an issue comment and the commenter is no longer a current assignee. Current assignee comments are still purged, and pull request comments from previous assignees remain purged so PR work is not credited through comment rewards.

## Verification

- `npx jest tests/parser/data-purge-research-credit.test.ts --runInBand`
- `npx prettier --check src/parser/data-purge-module.ts tests/parser/data-purge-research-credit.test.ts`
- `npx eslint src/parser/data-purge-module.ts tests/parser/data-purge-research-credit.test.ts`
- `npx bun run fetch-rpcs`
- `npx @ubiquity-os/plugin-manifest-tool@latest`
- `npx tsc --noEmit`