### PR TITLE
fix: downrank evaluator meta comments

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -628,12 +628,16 @@ export class ContentEvaluatorModule extends BaseModule {
         - Relation to the issue description
         - Connection to other comments
         - Contribution to issue resolution
+        - Whether the comment adds actionable requirements, implementation details, evidence, review feedback, or a decision that moves the issue forward
       5. Handle GitHub-flavored markdown:
         - Ignore text beginning with '>' as it references another comment
         - Distinguish between referenced text and the commenter's own words
         - Only evaluate the relevance of the commenter's original content
-      6. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
-      7. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
+      6. Score low-value meta discussion near 0, even when it mentions rewards, relevance, scoring, tests, or the evaluator itself, if it does not add concrete task-solving information.
+        - Low relevance example: "Relevance scoring could have done so much better here. Perhaps this conversation should be saved as a unit test." This is feedback about the evaluator, not a contribution to the issue being scored.
+        - Low relevance example: generic praise, agreement, status chatter, or discussion about how much the comment should be rewarded.
+      7. Return only a JSON object mapping each comment ID authored by ${username} to its score, with the following structure: {"<comment_id_1>": <score>, "<comment_id_2>": <score>, ...}
+      8. Do NOT wrap <score> in quotes. Each score must be a raw float (e.g., 0.85, not "0.85").
 
       Notes:
       - Even minor details may be significant.

--- a/tests/parser/content-evaluator-module.test.ts
+++ b/tests/parser/content-evaluator-module.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { ContentEvaluatorModule } from "../../src/parser/content-evaluator-module";
+import { ContextPlugin } from "../../src/types/plugin-input";
+import cfg from "../__mocks__/results/valid-configuration.json";
+
+const ctx = {
+  payload: {
+    issue: {
+      number: 223,
+    },
+    repository: {
+      name: "text-conversation-rewards",
+      owner: {
+        login: "ubiquity-os-marketplace",
+      },
+    },
+  },
+  config: cfg,
+  logger: new Logs("debug"),
+} as unknown as ContextPlugin;
+
+describe("ContentEvaluatorModule", () => {
+  describe("_generatePromptForComments", () => {
+    it("guides the model to score evaluator meta-discussion as low relevance", () => {
+      const module = new ContentEvaluatorModule(ctx);
+      const prompt = module._generatePromptForComments(
+        "Implement formal deduplication for recommendation matches.",
+        "gentlementlegen",
+        [
+          {
+            id: 1,
+            author: "gentlementlegen",
+            comment:
+              "Relevance scoring could have done so much better here. Perhaps this conversation should be saved as a unit test.",
+          },
+        ]
+      );
+
+      expect(prompt).toContain("Score low-value meta discussion near 0");
+      expect(prompt).toContain("rewards, relevance, scoring, tests, or the evaluator itself");
+      expect(prompt).toContain("Relevance scoring could have done so much better here");
+      expect(prompt).toContain('"1": <score>');
+    });
+  });
+});


### PR DESCRIPTION
﻿## Summary

Resolves #223.

Updates the issue-comment relevance prompt so meta-discussion about scoring, rewards, tests, or the evaluator itself is scored near zero when it does not add task-solving information.

The prompt now explicitly asks the model to distinguish concrete issue contributions from low-value commentary such as generic praise, reward/scoring chatter, or comments about the evaluator. It includes the issue's reported example as a low-relevance case so similar comments do not receive high relevance just because they mention relevance scoring.

## Verification

- `npx jest tests/parser/content-evaluator-module.test.ts --runInBand`
- `npx jest tests/parser/content-evaluator-module.test.ts tests/helpers/comment.test.ts tests/parser/data-purge-module.test.ts tests/fees.test.ts tests/parser/payment-module.test.ts tests/purging.test.ts --runInBand`
- `npx tsc --noEmit`
- `npx prettier --check src/parser/content-evaluator-module.ts tests/parser/content-evaluator-module.test.ts`
- `npx eslint src/parser/content-evaluator-module.ts tests/parser/content-evaluator-module.test.ts`