### PR TITLE
fix: down-rank process-only relevance comments

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -628,6 +628,8 @@ export class ContentEvaluatorModule extends BaseModule {
         - Relation to the issue description
         - Connection to other comments
         - Contribution to issue resolution
+        - Down-rank process-only comments: comments about assignment, recommendations, scoring, deadlines, or bot workflow should score low unless they add concrete information that helps solve the issue.
+        - Do not raise relevance because of the author's identity, reputation, or how often they are mentioned. Score only the original technical or task-solving content in the comment.
       5. Handle GitHub-flavored markdown:
         - Ignore text beginning with '>' as it references another comment
         - Distinguish between referenced text and the commenter's own words

--- a/tests/content-evaluator-prompt.test.ts
+++ b/tests/content-evaluator-prompt.test.ts
@@ -1,0 +1,42 @@
+import { ContentEvaluatorModule } from "../src/parser/content-evaluator-module";
+import { ContextPlugin } from "../src/types/plugin-input";
+
+function createContentEvaluatorModule() {
+  const context = {
+    config: {
+      incentives: {
+        contentEvaluator: {
+          openAi: {
+            maxRetries: 1,
+            tokenCountLimit: 1000,
+          },
+        },
+      },
+    },
+  } as unknown as ContextPlugin;
+
+  return new ContentEvaluatorModule(context);
+}
+
+describe("ContentEvaluatorModule prompt generation", () => {
+  it("instructs issue comment scoring to down-rank process-only and self-referential comments", () => {
+    const module = createContentEvaluatorModule();
+
+    const prompt = module._generatePromptForComments("Fix the recommendation quality for task assignment.", "alice", [
+      {
+        id: 1,
+        author: "alice",
+        comment: "This recommendation comment scored too high.",
+      },
+      {
+        id: 2,
+        author: "bob",
+        comment: "The implementation should compare recommendations against the task specification.",
+      },
+    ]);
+
+    expect(prompt).toContain("Down-rank process-only comments");
+    expect(prompt).toContain("comments about assignment, recommendations, scoring, deadlines, or bot workflow");
+    expect(prompt).toContain("Do not raise relevance because of the author's identity");
+  });
+});


### PR DESCRIPTION
Resolves #223

## Summary
- Down-ranks process-only relevance comments about assignment, recommendations, scoring, deadlines, or bot workflow unless they add concrete task-solving information.
- Prevents author identity, reputation, or mentions from increasing relevance.
- Adds a regression test for the issue-comment prompt instructions.

## Testing
- Not run locally: project dependencies were not installed in this workspace.