### PR TITLE
fix: filter empty review incentives

### DIFF
--- a/src/parser/review-incentivizer-module.ts
+++ b/src/parser/review-incentivizer-module.ts
@@ -3,7 +3,7 @@ import {
   ReviewIncentivizerConfiguration,
   reviewIncentivizerConfigurationType,
 } from "../configuration/review-incentivizer-config";
-import { GitHubPullRequestReviewState } from "../github-types";
+import { GitHubPullRequestReviewComment, GitHubPullRequestReviewState } from "../github-types";
 import { getExcludedFiles, shouldExcludeFile } from "../helpers/excluded-files";
 import { PullRequestData } from "../helpers/pull-request-data";
 import { IssueActivity } from "../issue-activity";
@@ -17,6 +17,32 @@ interface CommitDiff {
     addition: number;
     deletion: number;
   };
+}
+
+export function getRewardableReviewsByUser(
+  reviews: GitHubPullRequestReviewState[],
+  reviewComments: GitHubPullRequestReviewComment[] | null | undefined,
+  username: string
+) {
+  return reviews
+    .filter((review) => review.user?.login === username && hasReviewEvidence(review, reviewComments))
+    .sort((a, b) => getReviewTimestamp(a) - getReviewTimestamp(b));
+}
+
+function hasReviewEvidence(
+  review: GitHubPullRequestReviewState,
+  reviewComments: GitHubPullRequestReviewComment[] | null | undefined
+) {
+  if (review.body?.trim()) {
+    return true;
+  }
+  return Boolean(
+    reviewComments?.some((comment) => comment.pull_request_review_id === review.id && Boolean(comment.body?.trim()))
+  );
+}
+
+function getReviewTimestamp(review: GitHubPullRequestReviewState) {
+  return new Date(review.submitted_at ?? 0).getTime();
 }
 
 export class ReviewIncentivizerModule extends BaseModule {
@@ -46,7 +72,11 @@ export class ReviewIncentivizerModule extends BaseModule {
             this.context.logger.warn("The user is not allowed to receive rewards for a review", { username });
             continue;
           }
-          const reviewsByUser = linkedPullReviews.reviews.filter((v) => v.user?.login === username);
+          const reviewsByUser = getRewardableReviewsByUser(
+            linkedPullReviews.reviews,
+            linkedPullReviews.reviewComments,
+            username
+          );
           const headOwnerRepo = linkedPullReviews.self.head.repo?.full_name;
           const baseOwner = linkedPullReviews.self.base.repo.owner.login;
           const baseRepo = linkedPullReviews.self.base.repo.name;

--- a/tests/review-incentivizer.test.ts
+++ b/tests/review-incentivizer.test.ts
@@ -243,4 +243,50 @@ describe("Review Incentivizer", () => {
     expect(diff["modified.txt"]).toEqual({ addition: 2, deletion: 1 });
     expect(diff["removed.txt"]).toEqual(undefined);
   });
+
+  it("Should ignore empty approval reviews without comments", async () => {
+    const { getRewardableReviewsByUser } = await import("../src/parser/review-incentivizer-module");
+    const reviews = [
+      {
+        id: 3,
+        user: { login: "reviewer" },
+        body: " ",
+        state: "APPROVED",
+        submitted_at: "2024-01-03T00:00:00Z",
+      },
+      {
+        id: 1,
+        user: { login: "reviewer" },
+        body: "Left a summary review.",
+        state: "COMMENTED",
+        submitted_at: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: 2,
+        user: { login: "reviewer" },
+        body: " ",
+        state: "COMMENTED",
+        submitted_at: "2024-01-02T00:00:00Z",
+      },
+      {
+        id: 4,
+        user: { login: "other" },
+        body: "Review from another user.",
+        state: "COMMENTED",
+        submitted_at: "2024-01-04T00:00:00Z",
+      },
+    ] as RestEndpointMethodTypes["pulls"]["listReviews"]["response"]["data"];
+    const reviewComments = [
+      {
+        id: 10,
+        pull_request_review_id: 2,
+        user: { login: "reviewer" },
+        body: "Please address this line.",
+      },
+    ] as RestEndpointMethodTypes["pulls"]["listReviewComments"]["response"]["data"];
+
+    const rewardableReviews = getRewardableReviewsByUser(reviews, reviewComments, "reviewer");
+
+    expect(rewardableReviews.map((review) => review.id)).toEqual([1, 2]);
+  });
 });


### PR DESCRIPTION
## Summary

- filters review incentive calculations to reviews with an actual review body or associated review comments
- keeps empty approvals from receiving diff-based rewards when no review content was submitted
- adds a regression test for an empty approval following rewardable review activity

## Validation

- node node_modules/jest/bin/jest.js tests/review-incentivizer.test.ts --runInBand
- node node_modules/typescript/bin/tsc --noEmit
- node node_modules/eslint/bin/eslint.js src/parser/review-incentivizer-module.ts tests/review-incentivizer.test.ts
- node node_modules/prettier/bin/prettier.cjs --check src/parser/review-incentivizer-module.ts tests/review-incentivizer.test.ts

Resolves #260