### PR TITLE
Fix payout-mode handling for reopened issues after transfer marker

### DIFF
--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -352,10 +352,22 @@ export class PaymentModule extends BaseModule {
    - Transfer: Applies if autoTransferMode is set to true and no previous payout method has been used for the rewards.
   */
   async _getPayoutMode(data: Readonly<IssueActivity>): Promise<PayoutMode | null> {
+    const lastReopenedAt = data.events
+      .filter((event) => event.event === "reopened" && "created_at" in event && event.created_at)
+      .map((event) => new Date(event.created_at as string).getTime())
+      .filter((ts) => Number.isFinite(ts))
+      .sort((a, b) => b - a)[0];
+
     for (const comment of data.comments) {
       if (comment.body && comment.user?.type === "Bot") {
-        if (/"payoutMode":\s*"transfer"/.exec(comment.body)) return null;
-        else if (/"payoutMode":\s*"permit"/.exec(comment.body)) return "permit";
+        if (/"payoutMode":\s*"transfer"/.exec(comment.body)) {
+          const commentTimestamp = comment.created_at ? new Date(comment.created_at).getTime() : Number.NaN;
+          if (Number.isFinite(lastReopenedAt) && Number.isFinite(commentTimestamp) && lastReopenedAt > commentTimestamp) {
+            // Reopened after a previous transfer: allow permit mode so differential updates can be persisted safely.
+            return "permit";
+          }
+          return null;
+        } else if (/"payoutMode":\s*"permit"/.exec(comment.body)) return "permit";
       }
     }
     return this._autoTransferMode ? "transfer" : "permit";

--- a/tests/parser/payment-module.test.ts
+++ b/tests/parser/payment-module.test.ts
@@ -410,16 +410,29 @@ describe("payment-module.ts", () => {
       let paymentModule = new PaymentModule(ctx);
 
       let payoutMode = await paymentModule._getPayoutMode({
-        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" } }],
+        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" }, created_at: "2026-01-01T00:00:00Z" }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual(null);
 
       ctx.config.incentives.payment = { automaticTransferMode: true };
       paymentModule = new PaymentModule(ctx);
       payoutMode = await paymentModule._getPayoutMode({
-        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" } }],
+        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" }, created_at: "2026-01-01T00:00:00Z" }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual(null);
+    });
+
+    it("Should return `permit` if issue was reopened after a previous `transfer` payout marker", async () => {
+      ctx.config.incentives.payment = { automaticTransferMode: true };
+      const paymentModule = new PaymentModule(ctx);
+
+      const payoutMode = await paymentModule._getPayoutMode({
+        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" }, created_at: "2026-01-01T00:00:00Z" }],
+        events: [{ event: "reopened", created_at: "2026-01-02T00:00:00Z" }],
+      } as unknown as IssueActivity);
+      expect(payoutMode).toEqual("permit");
     });
 
     it("Should return `permit` if the `payoutMode` was already set to `permit` or `autoTransferMode` is set to `false`", async () => {
@@ -428,11 +441,13 @@ describe("payment-module.ts", () => {
 
       let payoutMode = await paymentModule._getPayoutMode({
         comments: [{ body: `...${PAYOUT_MODE_PERMIT}...`, user: { type: "Bot" } }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual("permit");
 
       payoutMode = await paymentModule._getPayoutMode({
         comments: [{ body: NO_MARKER_BODY, user: { type: "Bot" } }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual("permit");
     });
@@ -444,6 +459,7 @@ describe("payment-module.ts", () => {
 
       const payoutMode = await paymentModule._getPayoutMode({
         comments: [{ body: `...${PAYOUT_MODE_PERMIT}...`, user: { type: "Bot" } }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual("permit");
     });
@@ -454,6 +470,7 @@ describe("payment-module.ts", () => {
 
       const payoutMode = await paymentModule._getPayoutMode({
         comments: [{ body: NO_MARKER_BODY, user: { type: "Bot" } }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual("transfer");
     });


### PR DESCRIPTION
Resolves #455

Implements reopen-aware payout mode handling and regression test coverage.