### PR TITLE
test: validate non-collaborative payout artifacts

### DIFF
--- a/tests/payment-generatable.test.ts
+++ b/tests/payment-generatable.test.ts
@@ -212,6 +212,15 @@ interface UserData {
 interface JsonData {
   [key: string]: UserData;
 }
+
+function expectNoPayoutArtifacts(result: JsonData) {
+  for (const reward of Object.values(result)) {
+    expect(reward).not.toHaveProperty("permitUrl");
+    expect(reward).not.toHaveProperty("explorerUrl");
+    expect(reward).not.toHaveProperty("payoutMode");
+  }
+}
+
 let paymentResults: JsonData = {};
 describe.each(automaticTransferModeVector)("Payment Module Tests", (automaticTransferMode) => {
   let isAdminMocked: jest.Mock;
@@ -363,6 +372,7 @@ describe.each(automaticTransferModeVector)("Payment Module Tests", (automaticTra
 
       const result = JSON.parse(processor.dump());
       expect(result).not.toEqual(paymentResults);
+      expectNoPayoutArtifacts(result);
     });
   });
 });


### PR DESCRIPTION
Resolves #455

## Summary
- Adds an explicit regression assertion that non-admin, non-collaborative reward runs do not expose permit, transfer, or payout mode artifacts.
- Keeps the existing reward-result checks intact for collaborative and admin payment paths.

## Verification
- `npm exec --yes bun@latest -- x jest tests/payment-generatable.test.ts --runInBand`
- `npm exec --yes bun@latest -- x eslint tests/payment-generatable.test.ts`
- `git diff --check`
