### PR TITLE
test(payment): cover reopened payout precedence

### DIFF
--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -352,10 +352,22 @@ export class PaymentModule extends BaseModule {
    - Transfer: Applies if autoTransferMode is set to true and no previous payout method has been used for the rewards.
   */
   async _getPayoutMode(data: Readonly<IssueActivity>): Promise<PayoutMode | null> {
+    const lastReopenedAt = data.events
+      .filter((event) => event.event === "reopened" && "created_at" in event && event.created_at)
+      .map((event) => new Date(event.created_at as string).getTime())
+      .filter((ts) => Number.isFinite(ts))
+      .sort((a, b) => b - a)[0];
+
     for (const comment of data.comments) {
       if (comment.body && comment.user?.type === "Bot") {
-        if (/"payoutMode":\s*"transfer"/.exec(comment.body)) return null;
-        else if (/"payoutMode":\s*"permit"/.exec(comment.body)) return "permit";
+        if (/"payoutMode":\s*"transfer"/.exec(comment.body)) {
+          const commentTimestamp = comment.created_at ? new Date(comment.created_at).getTime() : Number.NaN;
+          if (Number.isFinite(lastReopenedAt) && Number.isFinite(commentTimestamp) && lastReopenedAt > commentTimestamp) {
+            // Reopened after a previous transfer: allow permit mode so differential updates can be persisted safely.
+            return "permit";
+          }
+          return null;
+        } else if (/"payoutMode":\s*"permit"/.exec(comment.body)) return "permit";
       }
     }
     return this._autoTransferMode ? "transfer" : "permit";

--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -358,17 +358,26 @@ export class PaymentModule extends BaseModule {
       .filter((ts) => Number.isFinite(ts))
       .sort((a, b) => b - a)[0];
 
-    for (const comment of data.comments) {
-      if (comment.body && comment.user?.type === "Bot") {
-        if (/"payoutMode":\s*"transfer"/.exec(comment.body)) {
-          const commentTimestamp = comment.created_at ? new Date(comment.created_at).getTime() : Number.NaN;
-          if (Number.isFinite(lastReopenedAt) && Number.isFinite(commentTimestamp) && lastReopenedAt > commentTimestamp) {
-            // Reopened after a previous transfer: allow permit mode so differential updates can be persisted safely.
-            return "permit";
-          }
-          return null;
-        } else if (/"payoutMode":\s*"permit"/.exec(comment.body)) return "permit";
-      }
+    const payoutModeComments = data.comments
+      .filter((comment) => comment.body && comment.user?.type === "Bot")
+      .map((comment) => ({
+        comment,
+        timestamp: comment.created_at ? new Date(comment.created_at).getTime() : Number.NaN,
+      }))
+      .filter(
+        ({ comment, timestamp }) =>
+          Number.isFinite(timestamp) && /"payoutMode":\s*"(transfer|permit)"/.test(comment.body ?? "")
+      )
+      .sort((a, b) => b.timestamp - a.timestamp);
+
+    for (const { comment, timestamp } of payoutModeComments) {
+      if (/"payoutMode":\s*"transfer"/.test(comment.body ?? "")) {
+        if (Number.isFinite(lastReopenedAt) && lastReopenedAt > timestamp) {
+          // Reopened after a previous transfer: allow permit mode so differential updates can be persisted safely.
+          return "permit";
+        }
+        return null;
+      } else if (/"payoutMode":\s*"permit"/.test(comment.body ?? "")) return "permit";
     }
     return this._autoTransferMode ? "transfer" : "permit";
   }

--- a/tests/parser/payment-module.test.ts
+++ b/tests/parser/payment-module.test.ts
@@ -410,16 +410,29 @@ describe("payment-module.ts", () => {
       let paymentModule = new PaymentModule(ctx);
 
       let payoutMode = await paymentModule._getPayoutMode({
-        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" } }],
+        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" }, created_at: "2026-01-01T00:00:00Z" }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual(null);
 
       ctx.config.incentives.payment = { automaticTransferMode: true };
       paymentModule = new PaymentModule(ctx);
       payoutMode = await paymentModule._getPayoutMode({
-        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" } }],
+        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" }, created_at: "2026-01-01T00:00:00Z" }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual(null);
+    });
+
+    it("Should return `permit` if issue was reopened after a previous `transfer` payout marker", async () => {
+      ctx.config.incentives.payment = { automaticTransferMode: true };
+      const paymentModule = new PaymentModule(ctx);
+
+      const payoutMode = await paymentModule._getPayoutMode({
+        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" }, created_at: "2026-01-01T00:00:00Z" }],
+        events: [{ event: "reopened", created_at: "2026-01-02T00:00:00Z" }],
+      } as unknown as IssueActivity);
+      expect(payoutMode).toEqual("permit");
     });
 
     it("Should return `permit` if the `payoutMode` was already set to `permit` or `autoTransferMode` is set to `false`", async () => {
@@ -428,11 +441,13 @@ describe("payment-module.ts", () => {
 
       let payoutMode = await paymentModule._getPayoutMode({
         comments: [{ body: `...${PAYOUT_MODE_PERMIT}...`, user: { type: "Bot" } }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual("permit");
 
       payoutMode = await paymentModule._getPayoutMode({
         comments: [{ body: NO_MARKER_BODY, user: { type: "Bot" } }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual("permit");
     });
@@ -444,6 +459,7 @@ describe("payment-module.ts", () => {
 
       const payoutMode = await paymentModule._getPayoutMode({
         comments: [{ body: `...${PAYOUT_MODE_PERMIT}...`, user: { type: "Bot" } }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual("permit");
     });
@@ -454,6 +470,7 @@ describe("payment-module.ts", () => {
 
       const payoutMode = await paymentModule._getPayoutMode({
         comments: [{ body: NO_MARKER_BODY, user: { type: "Bot" } }],
+        events: [],
       } as unknown as IssueActivity);
       expect(payoutMode).toEqual("transfer");
     });

--- a/tests/parser/payment-module.test.ts
+++ b/tests/parser/payment-module.test.ts
@@ -435,6 +435,20 @@ describe("payment-module.ts", () => {
       expect(payoutMode).toEqual("permit");
     });
 
+    it("Should return `permit` when the latest `reopened` event is after a previous `transfer` payout marker", async () => {
+      ctx.config.incentives.payment = { automaticTransferMode: true };
+      const paymentModule = new PaymentModule(ctx);
+
+      const payoutMode = await paymentModule._getPayoutMode({
+        comments: [{ body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" }, created_at: "2026-01-03T00:00:00Z" }],
+        events: [
+          { event: "reopened", created_at: "2026-01-01T00:00:00Z" },
+          { event: "reopened", created_at: "2026-01-04T00:00:00Z" },
+        ],
+      } as unknown as IssueActivity);
+      expect(payoutMode).toEqual("permit");
+    });
+
     it("Should return `permit` if the `payoutMode` was already set to `permit` or `autoTransferMode` is set to `false`", async () => {
       ctx.config.incentives.payment = { automaticTransferMode: false };
       const paymentModule = new PaymentModule(ctx);

--- a/tests/parser/payment-module.test.ts
+++ b/tests/parser/payment-module.test.ts
@@ -449,6 +449,20 @@ describe("payment-module.ts", () => {
       expect(payoutMode).toEqual("permit");
     });
 
+    it("Should return `null` when the latest payout marker is `transfer` and the issue was not reopened after it", async () => {
+      ctx.config.incentives.payment = { automaticTransferMode: true };
+      const paymentModule = new PaymentModule(ctx);
+
+      const payoutMode = await paymentModule._getPayoutMode({
+        comments: [
+          { body: `...${PAYOUT_MODE_PERMIT}...`, user: { type: "Bot" }, created_at: "2026-01-01T00:00:00Z" },
+          { body: `...${PAYOUT_MODE_TRANSFER}....`, user: { type: "Bot" }, created_at: "2026-01-02T00:00:00Z" },
+        ],
+        events: [],
+      } as unknown as IssueActivity);
+      expect(payoutMode).toEqual(null);
+    });
+
     it("Should return `permit` if the `payoutMode` was already set to `permit` or `autoTransferMode` is set to `false`", async () => {
       ctx.config.incentives.payment = { automaticTransferMode: false };
       const paymentModule = new PaymentModule(ctx);


### PR DESCRIPTION
/claim #301

Adds a focused regression test for the payout-mode precedence edge case where the latest reopened event should keep the mode at permit even if an earlier transfer marker exists.

Validation:
- & .\\node_modules\\.bin\\jest.cmd tests\\parser\\payment-module.test.ts --runInBand (26 passed)