### PR TITLE
fix: ignore multiline slash commands in comment rewards

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -8,6 +8,7 @@ import { BaseModule } from "../types/module";
 import { Result, GithubCommentScore as ResultComment } from "../types/results";
 
 type CommentType = Awaited<ReturnType<IssueActivity["getAllComments"]>>[0];
+const KNOWN_SLASH_COMMAND_REGEX = /^[^\S\n]*\/(ask|start|review|finish)\b/;
 
 /**
  * Removes the data in the comments that we do not want to be processed.
@@ -51,12 +52,14 @@ export class DataPurgeModule extends BaseModule {
 
   private _cleanCommentBody(body: string): string {
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+    const bodyWithoutQuotes = body.replace(/^>.*(?:\r?\n|$)/gm, "");
+    if (KNOWN_SLASH_COMMAND_REGEX.test(bodyWithoutQuotes)) {
+      return "";
+    }
     return (
-      body
-        // Remove quoted text
-        .replace(/^>.*$/gm, "")
+      bodyWithoutQuotes
         // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+        .replace(KNOWN_SLASH_COMMAND_REGEX, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/parser/data-purge-module.test.ts
+++ b/tests/parser/data-purge-module.test.ts
@@ -1,0 +1,49 @@
+import { DataPurgeModule } from "../../src/parser/data-purge-module";
+
+describe("DataPurgeModule", () => {
+  describe("_cleanCommentBody", () => {
+    const module = Object.create(DataPurgeModule.prototype) as unknown as {
+      _cleanCommentBody(body: string): string;
+    };
+
+    it("removes multiline slash commands and their content from reward evaluation", () => {
+      const result = module._cleanCommentBody(
+        "/ask\nThis follow-up text belongs to the command and should not be evaluated."
+      );
+
+      expect(result).toBe("");
+    });
+
+    it("removes multiline slash commands after quoted reply text", () => {
+      const result = module._cleanCommentBody("> previous comment\n/ask\nPlease score this");
+
+      expect(result).toBe("");
+    });
+
+    it("removes known slash commands with leading whitespace", () => {
+      const result = module._cleanCommentBody(" /start\nPlease start this task");
+
+      expect(result).toBe("");
+    });
+
+    it("preserves slash-prefixed paths at the start of normal comments", () => {
+      expect(module._cleanCommentBody("/api/v1/rewards\nLooks good")).toBe("/api/v1/rewards\nLooks good");
+      expect(module._cleanCommentBody("/src/parser/data-purge-module.ts\nLooks good")).toBe(
+        "/src/parser/data-purge-module.ts\nLooks good"
+      );
+      expect(module._cleanCommentBody("/some/random/path\nLooks good")).toBe("/some/random/path\nLooks good");
+    });
+
+    it("preserves slash-prefixed paths in normal multiline comments", () => {
+      const result = module._cleanCommentBody("Endpoint tested:\n/api/v1/rewards\nLooks good");
+
+      expect(result).toBe("Endpoint tested:\n/api/v1/rewards\nLooks good");
+    });
+
+    it("preserves normal comments that start with a blank line", () => {
+      const result = module._cleanCommentBody("\nThis is a normal comment.\n/api/v1/rewards");
+
+      expect(result).toBe("This is a normal comment.\n/api/v1/rewards");
+    });
+  });
+});


### PR DESCRIPTION
Resolves #242

## Summary

This update prevents multiline slash command comments from being evaluated as rewardable comment content.

The cleanup now removes quoted reply lines before checking whether the remaining comment body begins with a known slash command. This covers cases where a quoted block is followed by a multiline command, such as:

```text
> previous comment
/ask
Please check this
```

To avoid over-matching, only known commands are treated as commands. The known-command list is derived from the repo command schema (`/finish`) plus the commonly used Ubiquity commands (`/ask`, `/start`, `/review`). Normal comments that happen to contain slash-prefixed paths, such as `/api/v1/rewards`, are preserved.

## Changes

- Remove multiline slash command comments from reward evaluation.
- Handle quoted reply blocks before slash-command detection.
- Match against known slash commands rather than any line beginning with `/`, so slash-prefixed paths in normal comments are preserved.
- Handle leading whitespace before known commands.
- Add regression tests for multiline commands, quoted command replies, slash-prefixed paths, and indented commands.

## Tests

- `bun test tests/parser/data-purge-module.test.ts`
- `bun test tests/helpers/checkers.test.ts`

The added tests cover the quoted-reply edge case noted in earlier discussion.