### PR TITLE
feat: add Google Sheets task activity source

### DIFF
--- a/docs/google-sheets-task-source.md
+++ b/docs/google-sheets-task-source.md
@@ -1,0 +1,28 @@
+# Google Sheets Task Source
+
+The default task source remains GitHub. To evaluate a task from a published Google Sheets CSV export instead, configure `dataCollection.googleSheets`.
+
+```yaml
+dataCollection:
+  googleSheets:
+    csvUrl: "https://docs.google.com/spreadsheets/d/<id>/export?format=csv&gid=0"
+    taskId: "TASK-123"
+```
+
+By default, matching rows are selected with the `task_id` column. Each matching row can represent either the task specification or a contribution comment.
+
+## Default Columns
+
+| Column | Purpose |
+| --- | --- |
+| `task_id` | Task identifier used to select matching rows |
+| `title` | Task title |
+| `body` | Task specification or comment body |
+| `author` | Human author login/name |
+| `comment_id` | Stable comment id; generated from row order when blank |
+| `created_at` | ISO timestamp |
+| `assignee` | Optional assignee login/name |
+| `url` | Canonical task URL |
+| `price_label` | Optional price label such as `Price: 50 USD` |
+
+Every column name can be overridden in `dataCollection.googleSheets`.

--- a/src/configuration/data-collection-config.ts
+++ b/src/configuration/data-collection-config.ts
@@ -20,6 +20,32 @@ export const dataCollectionConfigurationType = Type.Object(
       description: "The delay between each retry, in milliseconds",
       examples: ["1000"],
     }),
+    /**
+     * Optional Google Sheets CSV source for task activity.
+     * When configured, rows matching `taskId` are normalized into the same issue/comment
+     * shape used by the existing reward pipeline.
+     */
+    googleSheets: Type.Optional(
+      Type.Object({
+        csvUrl: Type.String({
+          description: "Published Google Sheets CSV export URL.",
+          examples: ["https://docs.google.com/spreadsheets/d/<id>/export?format=csv&gid=0"],
+        }),
+        taskId: Type.String({
+          description: "Task identifier to load from the sheet.",
+          examples: ["TASK-123"],
+        }),
+        taskIdColumn: Type.String({ default: "task_id" }),
+        titleColumn: Type.String({ default: "title" }),
+        bodyColumn: Type.String({ default: "body" }),
+        authorColumn: Type.String({ default: "author" }),
+        commentIdColumn: Type.String({ default: "comment_id" }),
+        createdAtColumn: Type.String({ default: "created_at" }),
+        assigneeColumn: Type.String({ default: "assignee" }),
+        urlColumn: Type.String({ default: "url" }),
+        priceLabelColumn: Type.String({ default: "price_label" }),
+      })
+    ),
   },
   { default: {} }
 );

--- a/src/integrations/google-sheets-task-source.ts
+++ b/src/integrations/google-sheets-task-source.ts
@@ -1,0 +1,154 @@
+import { GitHubIssue, GitHubIssueComment, GitHubIssueEvent } from "../github-types";
+import { ContextPlugin } from "../types/plugin-input";
+
+type GoogleSheetsConfig = NonNullable<ContextPlugin["config"]["dataCollection"]["googleSheets"]>;
+
+type SheetRow = Record<string, string>;
+
+export type GoogleSheetsTaskActivity = {
+  self: GitHubIssue;
+  comments: GitHubIssueComment[];
+  events: GitHubIssueEvent[];
+};
+
+function parseCsv(text: string): SheetRow[] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let value = "";
+  let isQuoted = false;
+  let index = 0;
+
+  while (index < text.length) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (isQuoted) {
+      if (char === '"' && next === '"') {
+        value += '"';
+        index += 2;
+        continue;
+      } else if (char === '"') {
+        isQuoted = false;
+      } else {
+        value += char;
+      }
+    } else if (char === '"') {
+      isQuoted = true;
+    } else if (char === ",") {
+      row.push(value);
+      value = "";
+    } else if (char === "\n") {
+      row.push(value);
+      rows.push(row);
+      row = [];
+      value = "";
+    } else if (char !== "\r") {
+      value += char;
+    }
+    index += 1;
+  }
+
+  if (value || row.length) {
+    row.push(value);
+    rows.push(row);
+  }
+
+  const headers = rows.shift()?.map((header) => header.trim()) ?? [];
+  return rows
+    .filter((cells) => cells.some((cell) => cell.trim()))
+    .map((cells) => Object.fromEntries(headers.map((header, index) => [header, cells[index]?.trim() ?? ""])));
+}
+
+function stableNumber(value: string) {
+  const direct = Number(value);
+  if (Number.isFinite(direct) && direct > 0) {
+    return direct;
+  }
+  let hash = 0;
+  for (const char of value) {
+    hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  }
+  return hash || 1;
+}
+
+function user(login: string) {
+  const safeLogin = login || "unknown";
+  return {
+    id: stableNumber(safeLogin),
+    login: safeLogin,
+    type: "User",
+    html_url: `https://github.com/${safeLogin}`,
+  };
+}
+
+function getPayloadIssueUrl(context: ContextPlugin) {
+  if ("issue" in context.payload) {
+    return context.payload.issue.html_url;
+  }
+  return context.payload.pull_request.html_url;
+}
+
+function buildSelf(context: ContextPlugin, config: GoogleSheetsConfig, firstRow: SheetRow, taskRows: SheetRow[]) {
+  const taskId = firstRow[config.taskIdColumn] || config.taskId;
+  const taskUrl = firstRow[config.urlColumn] || getPayloadIssueUrl(context);
+  const author = firstRow[config.authorColumn] || context.payload.sender.login;
+  const assigneeLogin = firstRow[config.assigneeColumn];
+  const priceLabel = firstRow[config.priceLabelColumn];
+
+  return {
+    id: stableNumber(taskId),
+    number: stableNumber(taskId),
+    title: firstRow[config.titleColumn] || taskId,
+    body: firstRow[config.bodyColumn] || "",
+    html_url: taskUrl,
+    created_at: firstRow[config.createdAtColumn] || new Date(0).toISOString(),
+    user: user(author),
+    assignee: assigneeLogin ? user(assigneeLogin) : null,
+    assignees: assigneeLogin ? [user(assigneeLogin)] : [],
+    labels: priceLabel ? [{ name: priceLabel }] : [],
+    state: "closed",
+    state_reason: "completed",
+    comments: taskRows.length,
+  } as unknown as GitHubIssue;
+}
+
+function buildComment(context: ContextPlugin, config: GoogleSheetsConfig, row: SheetRow, index: number) {
+  const taskId = row[config.taskIdColumn] || config.taskId;
+  const commentId = row[config.commentIdColumn] || `${taskId}-${index + 1}`;
+  const taskUrl = row[config.urlColumn] || getPayloadIssueUrl(context);
+  const author = row[config.authorColumn] || context.payload.sender.login;
+
+  return {
+    id: stableNumber(commentId),
+    body: row[config.bodyColumn] || "",
+    html_url: `${taskUrl}#sheet-comment-${stableNumber(commentId)}`,
+    created_at: row[config.createdAtColumn] || new Date(0).toISOString(),
+    updated_at: row[config.createdAtColumn] || new Date(0).toISOString(),
+    user: user(author),
+    author_association: "CONTRIBUTOR",
+  } as unknown as GitHubIssueComment;
+}
+
+export async function loadGoogleSheetsTaskActivity(
+  context: ContextPlugin,
+  config: GoogleSheetsConfig
+): Promise<GoogleSheetsTaskActivity> {
+  const response = await fetch(config.csvUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Google Sheets CSV: ${response.status}`);
+  }
+
+  const rows = parseCsv(await response.text());
+  const taskRows = rows.filter((row) => row[config.taskIdColumn] === config.taskId);
+  if (!taskRows.length) {
+    throw new Error(`No Google Sheets rows matched task id "${config.taskId}" in column "${config.taskIdColumn}".`);
+  }
+
+  const firstRow = taskRows[0];
+  return {
+    self: buildSelf(context, config, firstRow, taskRows),
+    comments: taskRows
+      .filter((row) => row[config.bodyColumn])
+      .map((row, index) => buildComment(context, config, row, index)),
+    events: [],
+  };
+}

--- a/src/issue-activity.ts
+++ b/src/issue-activity.ts
@@ -15,6 +15,7 @@ import {
 } from "./github-types";
 import { areLoginsEquivalent } from "./helpers/github";
 import { isPullRequestEvent } from "./helpers/type-assertions";
+import { loadGoogleSheetsTaskActivity } from "./integrations/google-sheets-task-source";
 import {
   getIssue,
   getIssueComments,
@@ -61,6 +62,19 @@ export class IssueActivity {
     if (this.self) {
       this._context.logger.debug("The Issue Activity is already initialized.");
       return;
+    }
+    if (this._configuration.googleSheets) {
+      try {
+        const activity = await loadGoogleSheetsTaskActivity(this._context, this._configuration.googleSheets);
+        this.self = activity.self;
+        this.events = activity.events;
+        this.comments = activity.comments;
+        this.linkedMergedPullRequests = [];
+        this.linkedIssues = [];
+        return;
+      } catch (error) {
+        throw this._context.logger.error(`Could not fetch Google Sheets task data: ${error}`);
+      }
     }
     try {
       [this.self, this.events, this.comments, this.linkedMergedPullRequests, this.linkedIssues] = await Promise.all([

--- a/tests/google-sheets-task-source.test.ts
+++ b/tests/google-sheets-task-source.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { loadGoogleSheetsTaskActivity } from "../src/integrations/google-sheets-task-source";
+import { ContextPlugin } from "../src/types/plugin-input";
+
+describe("Google Sheets task source", () => {
+  it("normalizes matching sheet rows into issue activity", async () => {
+    const csv = [
+      "task_id,title,body,author,comment_id,created_at,assignee,url,price_label",
+      "TASK-1,Spec,Build this,alice,spec,2026-01-01T00:00:00.000Z,bob,https://github.com/org/repo/issues/1,Price: 50 USD",
+      "TASK-1,Spec,Useful comment,carol,c1,2026-01-01T01:00:00.000Z,bob,https://github.com/org/repo/issues/1,Price: 50 USD",
+      "TASK-2,Other,Ignored,dave,c2,2026-01-01T02:00:00.000Z,,https://github.com/org/repo/issues/2,Price: 10 USD",
+    ].join("\n");
+    jest.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(csv));
+
+    const activity = await loadGoogleSheetsTaskActivity(
+      {
+        logger: new Logs("debug"),
+        payload: {
+          sender: { login: "sender" },
+          issue: { html_url: "https://github.com/org/repo/issues/1" },
+        },
+      } as unknown as ContextPlugin,
+      {
+        csvUrl: "https://docs.google.com/sheet.csv",
+        taskId: "TASK-1",
+        taskIdColumn: "task_id",
+        titleColumn: "title",
+        bodyColumn: "body",
+        authorColumn: "author",
+        commentIdColumn: "comment_id",
+        createdAtColumn: "created_at",
+        assigneeColumn: "assignee",
+        urlColumn: "url",
+        priceLabelColumn: "price_label",
+      }
+    );
+
+    expect(activity.self.title).toBe("Spec");
+    expect(activity.self.assignee?.login).toBe("bob");
+    expect(activity.self.labels).toEqual([{ name: "Price: 50 USD" }]);
+    expect(activity.comments).toHaveLength(2);
+    expect(activity.comments.map((comment) => comment.user?.login)).toEqual(["alice", "carol"]);
+  });
+});


### PR DESCRIPTION
Closes #385

## Summary

- Adds an optional `dataCollection.googleSheets` source that loads task activity from a published Google Sheets CSV export.
- Normalizes matching sheet rows into the existing issue/comment activity shape, so the reward pipeline can run without requiring GitHub as the source of task activity.
- Keeps GitHub as the default source and only uses Google Sheets when explicitly configured.
- Adds operator docs for the default sheet columns and focused normalization coverage.

This is a first decoupling slice: it creates a non-GitHub task source boundary while preserving the existing reward modules.

## Verification

- `git diff --check`
- Fresh clone accepted `text_conversation_rewards_issue385_google_sheets_task_source.patch`
- Local Bun dependency install completed during revalidation
- Changed-file lint/format and TypeScript checks passed during the latest clean-queue validation pass

