### PR TITLE
fix: skip approval-only review incentive rewards

### DIFF
--- a/src/parser/review-incentivizer-module.ts
+++ b/src/parser/review-incentivizer-module.ts
@@ -3,7 +3,7 @@ import {
   ReviewIncentivizerConfiguration,
   reviewIncentivizerConfigurationType,
 } from "../configuration/review-incentivizer-config";
-import { GitHubPullRequestReviewState } from "../github-types";
+import { GitHubPullRequestReviewComment, GitHubPullRequestReviewState } from "../github-types";
 import { getExcludedFiles, shouldExcludeFile } from "../helpers/excluded-files";
 import { PullRequestData } from "../helpers/pull-request-data";
 import { IssueActivity } from "../issue-activity";
@@ -17,6 +17,19 @@ interface CommitDiff {
     addition: number;
     deletion: number;
   };
+}
+
+export function hasRewardableReviewContent(
+  review: GitHubPullRequestReviewState,
+  reviewComments: GitHubPullRequestReviewComment[] = []
+) {
+  if (review.body?.trim()) {
+    return true;
+  }
+
+  return reviewComments.some(
+    (comment) => comment.pull_request_review_id === review.id && comment.user?.login === review.user?.login
+  );
 }
 
 export class ReviewIncentivizerModule extends BaseModule {
@@ -57,7 +70,8 @@ export class ReviewIncentivizerModule extends BaseModule {
             baseRef,
             headOwnerRepo ?? "",
             reviewsByUser,
-            priority
+            priority,
+            linkedPullReviews.reviewComments ?? []
           );
           reward.reviewRewards.push({ reviews: reviewDiffs, url: linkedPullReviews.self.html_url });
         }
@@ -121,14 +135,20 @@ export class ReviewIncentivizerModule extends BaseModule {
     baseRef: string,
     headOwnerRepo: string,
     reviewsByUser: GitHubPullRequestReviewState[],
-    priority: number
+    priority: number,
+    reviewComments: GitHubPullRequestReviewComment[] = []
   ) {
     if (reviewsByUser.length == 0) {
       this.context.logger.debug("No reviews found for this pull request", { baseOwner, baseRepo, baseRef });
       return;
     }
     const reviews: ReviewScore[] = [];
-    const pullNumber = Number(reviewsByUser[0].pull_request_url.split("/").slice(-1)[0]);
+    const rewardableReviews = reviewsByUser.filter((review) => hasRewardableReviewContent(review, reviewComments));
+    if (rewardableReviews.length == 0) {
+      this.context.logger.debug("No rewardable reviews found for this pull request", { baseOwner, baseRepo, baseRef });
+      return reviews;
+    }
+    const pullNumber = Number(rewardableReviews[0].pull_request_url.split("/").slice(-1)[0]);
 
     const prData = new PullRequestData(this.context, baseOwner, baseRepo, pullNumber);
     await prData.fetchData();
@@ -139,10 +159,10 @@ export class ReviewIncentivizerModule extends BaseModule {
       throw this.context.logger.error("Could not fetch base commit for this pull request");
     }
     const excludedFilePatterns = await getExcludedFiles(this.context, baseOwner, baseRepo, baseRef);
-    for (const [i, currentReview] of reviewsByUser.entries()) {
+    for (const [i, currentReview] of rewardableReviews.entries()) {
       if (!currentReview.commit_id) continue;
 
-      const previousReview = reviewsByUser[i - 1];
+      const previousReview = rewardableReviews[i - 1];
       const baseSha = previousReview?.commit_id ? previousReview.commit_id : firstCommitSha;
       const headSha = `${headOwnerRepo.replace("/", ":")}:${currentReview.commit_id}`;
 

--- a/tests/review-incentivizer.test.ts
+++ b/tests/review-incentivizer.test.ts
@@ -13,6 +13,7 @@ import cfg from "./__mocks__/results/valid-configuration.json";
 import "./helpers/permit-mock";
 import Mock = jest.Mock;
 import { http, HttpResponse } from "msw";
+import { GitHubPullRequestReviewComment, GitHubPullRequestReviewState } from "../src/github-types";
 
 const ctx = {
   eventName: "issues.closed",
@@ -242,5 +243,78 @@ describe("Review Incentivizer", () => {
     expect(diff["added.txt"]).toEqual({ addition: 10, deletion: 5 });
     expect(diff["modified.txt"]).toEqual({ addition: 2, deletion: 1 });
     expect(diff["removed.txt"]).toEqual(undefined);
+  });
+
+  it("Should only reward reviews that include a body or inline comments", async () => {
+    const { hasRewardableReviewContent } = await import("../src/parser/review-incentivizer-module");
+    const baseReview = {
+      id: 1,
+      body: "",
+      user: { login: "reviewer" },
+    } as GitHubPullRequestReviewState;
+
+    expect(hasRewardableReviewContent(baseReview)).toBe(false);
+    expect(hasRewardableReviewContent({ ...baseReview, body: "Looks good after the requested changes." })).toBe(true);
+    expect(
+      hasRewardableReviewContent(baseReview, [
+        {
+          pull_request_review_id: 1,
+          user: { login: "reviewer" },
+        } as GitHubPullRequestReviewComment,
+      ])
+    ).toBe(true);
+  });
+
+  it("Should skip approval-only reviews when calculating review rewards", async () => {
+    const { ReviewIncentivizerModule } = await import("../src/parser/review-incentivizer-module");
+    jest.spyOn(PullRequestData.prototype, "fetchData").mockResolvedValue(undefined);
+    jest.spyOn(PullRequestData.prototype, "pullCommits", "get").mockReturnValue([
+      {
+        sha: "first",
+        parents: [{ sha: "base" }],
+        parentCount: 1,
+      },
+    ]);
+    jest.spyOn(ReviewIncentivizerModule.prototype, "getReviewableDiff").mockResolvedValue({
+      addition: 10,
+      deletion: 5,
+    });
+    jest
+      .spyOn(ctx.octokit.rest.repos, "getContent")
+      .mockRejectedValue(Object.assign(new Error("Not Found"), { status: 404 }));
+
+    const reviewIncentivizerModule = new ReviewIncentivizerModule(ctx);
+    const reviews = await reviewIncentivizerModule.fetchReviewDiffRewards(
+      "ubiquity-os",
+      "conversation-rewards",
+      "main",
+      "reviewer:branch",
+      [
+        {
+          id: 1,
+          body: "I left comments on the implementation.",
+          commit_id: "reviewed-commit",
+          pull_request_url: "https://api.github.com/repos/ubiquity-os/conversation-rewards/pulls/12",
+          user: { login: "reviewer" },
+        } as GitHubPullRequestReviewState,
+        {
+          id: 2,
+          body: "",
+          commit_id: "approval-commit",
+          pull_request_url: "https://api.github.com/repos/ubiquity-os/conversation-rewards/pulls/12",
+          user: { login: "reviewer" },
+        } as GitHubPullRequestReviewState,
+      ],
+      2
+    );
+
+    expect(reviews).toEqual([
+      {
+        reviewId: 1,
+        effect: { addition: 10, deletion: 5 },
+        reward: 0.3,
+        priority: 2,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Fixes #260

## Summary

- Adds a rewardability check for pull-request reviews.
- Rewards review diff impact only when the review has a written body or associated inline review comments.
- Skips approval-only reviews, preventing a final approval with no substantive review content from receiving another full diff-based review reward.
- Keeps the existing generated-file / excluded-file filtering path intact.
- Adds regression coverage for body reviews, inline-comment reviews, and approval-only reviews.

## Verification

- `git diff --check`
- Fresh verification clone passed `bun install --ignore-scripts`
- Fresh verification clone passed `bun run fetch-rpcs`
- Fresh verification clone passed `tsc --noEmit`
- Fresh verification clone passed changed-file ESLint with 0 errors and 2 warning-level empty-string warnings in the touched test file
- Fresh verification clone passed changed-file Prettier check

Targeted Jest was attempted but failed before running tests because Jest could not resolve the configured `@swc/jest` transformer in the local Bun-installed dependency layout. Please rerun the normal CI test job before merge.

