### PR TITLE
Fix reward generation collaboration gate

### DIFF
--- a/src/helpers/checkers.ts
+++ b/src/helpers/checkers.ts
@@ -9,19 +9,14 @@ const COLLABORATOR_REVIEW_ASSOCIATIONS: ReviewAuthorAssociation[] = ["COLLABORAT
 
 export function isCollaborative(data: Readonly<IssueActivity>) {
   if (!data.self?.closed_by || !data.self.user) return false;
-  const issueCreator = data.self.user;
+  const rewardedUserIds = getRewardedUserIds(data);
+  if (!rewardedUserIds.size) return false;
 
-  if (data.self.closed_by.id === issueCreator.id) {
-    const pricingEventsByNonAssignee = data.events.find(
-      (event) =>
-        event.event === "labeled" &&
-        "label" in event &&
-        (event.label.name.startsWith("Time: ") || event.label.name.startsWith("Priority: ")) &&
-        event.actor.id !== issueCreator.id
-    );
-    return !!pricingEventsByNonAssignee || !!nonAssigneeApprovedReviews(data);
-  }
-  return true;
+  return (
+    hasSpecificationByDifferentHuman(data, rewardedUserIds) ||
+    hasAssignmentByDifferentHuman(data, rewardedUserIds) ||
+    nonAssigneeApprovedReviews(data)
+  );
 }
 
 export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {
@@ -38,12 +33,71 @@ export function nonAssigneeApprovedReviews(data: Readonly<IssueActivity>) {
     return hasApprovedReviewByCollaborator(linkedPullRequest.reviews, excludedAuthorIds);
   }
 
-  const assigneeId = data.self?.assignee?.id;
-  if (!assigneeId || !linkedPullRequest.self) {
+  const assigneeIds = getIssueAssigneeIds(data);
+  if (!assigneeIds.size || !linkedPullRequest.self) {
     return false;
   }
 
-  return hasIssueContextApprovedReview(linkedPullRequest.self, linkedPullRequest.reviews, assigneeId);
+  return hasIssueContextApprovedReview(linkedPullRequest.self, linkedPullRequest.reviews, assigneeIds);
+}
+
+function getRewardedUserIds(data: Readonly<IssueActivity>) {
+  const userIds = getIssueAssigneeIds(data);
+
+  if (data.self?.pull_request) {
+    addUserId(userIds, data.self.user);
+    for (const linkedPullRequest of data.linkedMergedPullRequests) {
+      addUserId(userIds, linkedPullRequest.self?.user);
+    }
+  }
+
+  return userIds;
+}
+
+function getIssueAssigneeIds(data: Readonly<IssueActivity>) {
+  const userIds = new Set<string>();
+
+  for (const assignee of data.self?.assignees ?? []) {
+    addUserId(userIds, assignee);
+  }
+  addUserId(userIds, data.self?.assignee);
+
+  return userIds;
+}
+
+function hasSpecificationByDifferentHuman(data: Readonly<IssueActivity>, excludedUserIds: Set<string>) {
+  if (data.self?.pull_request) {
+    return false;
+  }
+  return isDifferentHuman(data.self?.user, excludedUserIds);
+}
+
+function hasAssignmentByDifferentHuman(data: Readonly<IssueActivity>, excludedUserIds: Set<string>) {
+  return data.events.some((event) => {
+    if (event.event !== "assigned") {
+      return false;
+    }
+
+    if ("assignee" in event && event.assignee?.id && !excludedUserIds.has(String(event.assignee.id))) {
+      return false;
+    }
+
+    const assigner = "assigner" in event && event.assigner ? event.assigner : event.actor;
+    return isDifferentHuman(assigner, excludedUserIds);
+  });
+}
+
+function addUserId(userIds: Set<string>, user: { id?: number | null } | null | undefined) {
+  if (user?.id) {
+    userIds.add(String(user.id));
+  }
+}
+
+function isDifferentHuman(
+  user: { id?: number | null; type?: string | null } | null | undefined,
+  excludedUserIds: Set<string>
+) {
+  return Boolean(user?.id && user.type !== "Bot" && !excludedUserIds.has(String(user.id)));
 }
 
 function hasApprovedReviewByCollaborator(
@@ -57,6 +111,7 @@ function hasApprovedReviewByCollaborator(
   return reviews.some(
     (review) =>
       Boolean(review.user?.id) &&
+      review.user?.type !== "Bot" &&
       !excludedUserIds.has(String(review.user?.id)) &&
       review.state === "APPROVED" &&
       isReviewByCollaborator(review)
@@ -66,7 +121,7 @@ function hasApprovedReviewByCollaborator(
 function hasIssueContextApprovedReview(
   pullRequest: GitHubPullRequest,
   reviews: GitHubPullRequestReviewState[] | null | undefined,
-  assigneeId: number
+  excludedUserIds: Set<string>
 ) {
   if (!reviews) {
     return false;
@@ -75,7 +130,8 @@ function hasIssueContextApprovedReview(
   return reviews.some(
     (review) =>
       Boolean(review.user?.id) &&
-      review.user?.id !== assigneeId &&
+      review.user?.type !== "Bot" &&
+      !excludedUserIds.has(String(review.user?.id)) &&
       review.state === "APPROVED" &&
       !isReviewRequestedForUser(pullRequest, review)
   );

--- a/tests/helpers/checkers.test.ts
+++ b/tests/helpers/checkers.test.ts
@@ -5,13 +5,15 @@ import type { IssueActivity } from "../../src/issue-activity";
 type User = {
   id: number;
   login: string;
+  type?: string;
 };
 
-const author = { id: 1, login: "author" };
-const assignee = { id: 2, login: "assignee" };
-const reviewer = { id: 3, login: "reviewer" };
-const issueAuthor = { id: 4, login: "issue-author" };
-const outsideReviewer = { id: 5, login: "outside-reviewer" };
+const author = { id: 1, login: "author", type: "User" };
+const assignee = { id: 2, login: "assignee", type: "User" };
+const reviewer = { id: 3, login: "reviewer", type: "User" };
+const issueAuthor = { id: 4, login: "issue-author", type: "User" };
+const outsideReviewer = { id: 5, login: "outside-reviewer", type: "User" };
+const bot = { id: 6, login: "ubiquity-os[bot]", type: "Bot" };
 
 function createReview(
   user: User,
@@ -25,27 +27,55 @@ function createReview(
   } as GitHubPullRequestReviewState;
 }
 
+function createLabeledEvent(actor: User, labelName = "Time: <1 Hour") {
+  return {
+    actor,
+    event: "labeled",
+    label: {
+      name: labelName,
+    },
+  };
+}
+
+function createAssignedEvent(assigner: User, assignedUser: User) {
+  return {
+    actor: assigner,
+    assignee: assignedUser,
+    assigner,
+    event: "assigned",
+  };
+}
+
 function createActivity({
   pullRequestContext = false,
   issueAssignee,
+  issueAssignees,
+  issueCloser,
+  issueCreator = author,
   linkedIssueAuthor,
   reviews = [],
   requestedReviewers = [],
+  events = [],
 }: {
   pullRequestContext?: boolean;
   issueAssignee?: User;
+  issueAssignees?: User[];
+  issueCloser?: User;
+  issueCreator?: User;
   linkedIssueAuthor?: User;
   reviews?: GitHubPullRequestReviewState[];
   requestedReviewers?: User[];
+  events?: unknown[];
 }) {
   return {
     self: {
-      user: author,
-      closed_by: author,
+      user: issueCreator,
+      closed_by: issueCloser ?? issueCreator,
       assignee: issueAssignee,
+      assignees: issueAssignees ?? (issueAssignee ? [issueAssignee] : []),
       pull_request: pullRequestContext ? { html_url: "https://github.com/owner/repo/pull/1" } : undefined,
     },
-    events: [],
+    events,
     linkedMergedPullRequests: [
       {
         self: {
@@ -129,9 +159,10 @@ describe("collaboration checks", () => {
       expect(isCollaborative(activity)).toBe(false);
     });
 
-    it("keeps the issue-context assignee behavior", () => {
+    it("keeps the issue-context assignee review behavior", () => {
       const activity = createActivity({
         issueAssignee: assignee,
+        issueCreator: assignee,
         reviews: [createReview(reviewer)],
       });
 
@@ -142,9 +173,72 @@ describe("collaboration checks", () => {
     it("does not treat an empty issue-context review list as collaborative", () => {
       const activity = createActivity({
         issueAssignee: assignee,
+        issueCreator: assignee,
       });
 
       expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not count an approval from another rewarded assignee", () => {
+      const activity = createActivity({
+        issueAssignee: assignee,
+        issueAssignees: [assignee, reviewer],
+        issueCreator: assignee,
+        reviews: [createReview(reviewer)],
+      });
+
+      expect(nonAssigneeApprovedReviews(activity)).toBe(false);
+      expect(isCollaborative(activity)).toBe(false);
+    });
+  });
+
+  describe("isCollaborative", () => {
+    it("treats a different issue author as a specification signal", () => {
+      const activity = createActivity({
+        issueAssignee: assignee,
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("does not treat pricing labels alone as collaboration for a self-authored reward", () => {
+      const activity = createActivity({
+        events: [createLabeledEvent(reviewer), createLabeledEvent(bot, "Priority: 2 (Medium)")],
+        issueAssignee: assignee,
+        issueCreator: assignee,
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("treats assignment by another human as collaboration", () => {
+      const activity = createActivity({
+        events: [createAssignedEvent(reviewer, assignee)],
+        issueAssignee: assignee,
+        issueCreator: assignee,
+      });
+
+      expect(isCollaborative(activity)).toBe(true);
+    });
+
+    it("does not treat self-assignment as collaboration", () => {
+      const activity = createActivity({
+        events: [createAssignedEvent(assignee, assignee)],
+        issueAssignee: assignee,
+        issueCreator: assignee,
+      });
+
+      expect(isCollaborative(activity)).toBe(false);
+    });
+
+    it("does not treat bot assignment as collaboration", () => {
+      const activity = createActivity({
+        events: [createAssignedEvent(bot, assignee)],
+        issueAssignee: assignee,
+        issueCreator: assignee,
+      });
+
       expect(isCollaborative(activity)).toBe(false);
     });
   });


### PR DESCRIPTION
/claim #455

Fixes #455

## Summary

- Require non-admin reward generation to have a different human signal before payment/comment generation proceeds.
- Count a different issue author as specification involvement, a different human assignment as assignment involvement, or an approved non-recipient review as review involvement.
- Stop treating pricing labels, self-assignment, bot assignment, or approval from another rewarded assignee as sufficient collaboration.

## Root cause

`isCollaborative` treated a non-author pricing label or a closer different from the issue author as enough collaboration. That allowed self-authored/self-assigned rewards to pass the gate without a different human providing specification, assignment, or review.

## Validation

- `node node_modules/jest/bin/jest.js tests/helpers/checkers.test.ts --runInBand --coverage=false`
- `node node_modules/prettier/bin/prettier.cjs --check src/helpers/checkers.ts tests/helpers/checkers.test.ts`
- `node node_modules/eslint/bin/eslint.js src/helpers/checkers.ts tests/helpers/checkers.test.ts`
- `git diff --check`

Note: `tsc --noEmit` was also attempted. It now fails only on existing repository setup/generated-file issues: missing `src/types/rpcs.json` and the downstream implicit `chain` type in `src/parser/payment-module.ts`.
