### PR TITLE
fix: ignore multiline slash command content

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -31,6 +31,31 @@ function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
   );
 }
 
+export function stripSlashCommandBlocks(content: string) {
+  const lines = content.split(/\r?\n/);
+  const result: string[] = [];
+  let isCommandBlock = false;
+
+  for (const line of lines) {
+    if (/^\s*\/[A-Za-z][\w-]*(?:\s|$)/.test(line)) {
+      isCommandBlock = true;
+      continue;
+    }
+
+    if (isCommandBlock) {
+      if (!line.trim()) {
+        isCommandBlock = false;
+        result.push(line);
+      }
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n").trim();
+}
+
 /**
  * Evaluates and rates comments.
  */
@@ -94,7 +119,12 @@ export class ContentEvaluatorModule extends BaseModule {
               (comment) =>
                 comment.commentType & CommentKind.ISSUE && !(comment.commentType & CommentAssociation.SPECIFICATION)
             )
-            .map((comment) => ({ id: comment.id, comment: comment.content, author: user }))
+            .map((comment) => ({
+              id: comment.id,
+              comment: stripSlashCommandBlocks(comment.content),
+              author: user,
+            }))
+            .filter((comment) => comment.comment.length)
         );
       }
     }
@@ -253,6 +283,8 @@ export class ContentEvaluatorModule extends BaseModule {
       let currentRelevance = 1; // For comments not in fixed relevance types and missed by OpenAI evaluation
       if (this._fixedRelevances[currentComment.commentType]) {
         currentRelevance = this._fixedRelevances[currentComment.commentType];
+      } else if (!stripSlashCommandBlocks(currentComment.content).length) {
+        currentRelevance = 0;
       } else if (!isNaN(relevancesByAi[currentComment.id])) {
         currentRelevance = relevancesByAi[currentComment.id];
       }
@@ -297,17 +329,23 @@ export class ContentEvaluatorModule extends BaseModule {
     const commentsToEvaluate: CommentToEvaluate[] = [];
     const prCommentsToEvaluate: PrCommentToEvaluate[] = [];
     for (const currentComment of commentsWithScore) {
+      const comment = stripSlashCommandBlocks(currentComment.content);
+
+      if (!comment.length) {
+        continue;
+      }
+
       if (!this._fixedRelevances[currentComment.commentType]) {
         if (currentComment.commentType & CommentKind.PULL) {
           prCommentsToEvaluate.push({
             id: currentComment.id,
-            comment: currentComment.content,
+            comment,
             diffHunk: currentComment?.diffHunk,
           });
         } else {
           commentsToEvaluate.push({
             id: currentComment.id,
-            comment: currentComment.content,
+            comment,
           });
         }
       }

--- a/tests/content-evaluator-module.test.ts
+++ b/tests/content-evaluator-module.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { CommentKind } from "../src/configuration/comment-types";
+import { ContentEvaluatorModule, stripSlashCommandBlocks } from "../src/parser/content-evaluator-module";
+import { GithubCommentScore } from "../src/types/results";
+
+const EMPTY_COMMAND_RESULT = String();
+
+function createModule() {
+  return new ContentEvaluatorModule({
+    config: {
+      incentives: {
+        contentEvaluator: {
+          multipliers: [],
+          openAi: {
+            maxRetries: 1,
+            tokenCountLimit: 10000,
+          },
+        },
+      },
+    },
+    payload: {
+      issue: {},
+    },
+  } as never);
+}
+
+function createComment(id: number, content: string, commentType = CommentKind.ISSUE): GithubCommentScore {
+  return {
+    id,
+    content,
+    commentType,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    url: `https://example.com/comments/${id}`,
+    score: {
+      multiplier: 1,
+      reward: 1,
+      authorship: 1,
+    },
+  };
+}
+
+describe("ContentEvaluatorModule slash command filtering", () => {
+  it("removes multiline slash command blocks while preserving later discussion", () => {
+    expect(stripSlashCommandBlocks("/ask\nplease summarize this issue")).toBe(EMPTY_COMMAND_RESULT);
+    expect(stripSlashCommandBlocks("Useful note\n/ask\nplease summarize\n\nFollow up")).toBe(
+      "Useful note\n\nFollow up"
+    );
+    expect(stripSlashCommandBlocks("This mentions /ask inline and should stay")).toBe(
+      "This mentions /ask inline and should stay"
+    );
+  });
+
+  it("omits command-only comments from LLM prompt input", () => {
+    const module = createModule();
+    const split = module._splitCommentsByPrompt([
+      createComment(1, "/ask\nplease summarize this issue"),
+      createComment(2, "/ask\nplease summarize\n\nActual contribution"),
+      createComment(3, "Regular contribution"),
+      createComment(4, "/ask\nplease review this diff", CommentKind.PULL),
+      createComment(5, "/ask\nplease review\n\nThis line matters", CommentKind.PULL),
+    ]);
+
+    expect(split.commentsToEvaluate).toEqual([
+      { id: 2, comment: "Actual contribution" },
+      { id: 3, comment: "Regular contribution" },
+    ]);
+    expect(split.prCommentsToEvaluate).toEqual([{ id: 5, comment: "This line matters", diffHunk: undefined }]);
+  });
+
+  it("assigns zero relevance and reward to command-only comments", async () => {
+    const module = createModule();
+    jest.spyOn(module, "_evaluateComments").mockResolvedValue({ 2: 1 });
+
+    const comments = [
+      createComment(1, "/ask\nplease summarize this issue"),
+      createComment(2, "Implemented the requested fix"),
+    ];
+    const result = await module._processComment("alice", comments, "Issue body", [
+      { id: 2, author: "alice", comment: "Implemented the requested fix" },
+    ]);
+
+    expect(result[0].score?.relevance).toBe(0);
+    expect(result[0].score?.reward).toBe(0);
+    expect(result[1].score?.relevance).toBe(1);
+    expect(result[1].score?.reward).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Strip multiline slash command blocks before content evaluation prompts are built.
- Skip command-only comments from LLM evaluation input and assign them zero relevance/reward.
- Add focused coverage for command-only and mixed command/comment bodies.

Closes #242

## Validation
- `bun run jest:test tests/content-evaluator-module.test.ts --coverage=false`
- `bun eslint src/parser/content-evaluator-module.ts tests/content-evaluator-module.test.ts`
- `bun prettier --check src/parser/content-evaluator-module.ts tests/content-evaluator-module.test.ts`
- `git diff --check`