### PR TITLE
Clarify missing token network error

### DIFF
--- a/src/parser/github-comment-module.ts
+++ b/src/parser/github-comment-module.ts
@@ -77,9 +77,24 @@ export class GithubCommentModule extends BaseModule {
       return cached;
     }
     const tokenContract = await getContract(config.evmNetworkId, config.erc20RewardToken, ERC20_ABI);
-    const symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    let symbol: string;
+    try {
+      symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    } catch (error) {
+      if (this._isTokenSymbolCallException(error)) {
+        throw new Error(`This token ${config.erc20RewardToken} was not found on network ID ${config.evmNetworkId}`);
+      }
+      throw error;
+    }
     this._tokenSymbolCache.set(key, symbol);
     return symbol;
+  }
+
+  private _isTokenSymbolCallException(error: unknown) {
+    const message = error instanceof Error ? error.message : "";
+    const code =
+      typeof error === "object" && error !== null && "code" in error ? (error as { code?: unknown }).code : undefined;
+    return code === "CALL_EXCEPTION" || message.includes("call revert exception");
   }
 
   private async _getTokenDisplayForUser(username: string) {

--- a/tests/github-comment-simplification-rounding.test.ts
+++ b/tests/github-comment-simplification-rounding.test.ts
@@ -7,7 +7,7 @@ import { mockWeb3Module } from "./helpers/web3-mocks";
 
 const issueUrl = "https://github.com/ubiquity/work.ubq.fi/issues/69";
 
-mockWeb3Module();
+const web3Mocks = mockWeb3Module();
 
 jest.mock("@actions/github", () => ({
   default: {},
@@ -26,6 +26,8 @@ describe("GithubCommentModule Simplification Rounding", () => {
   let githubCommentModule: InstanceType<typeof import("../src/parser/github-comment-module").GithubCommentModule>;
 
   beforeEach(async () => {
+    web3Mocks.Erc20Wrapper.getSymbol.mockReset();
+    web3Mocks.Erc20Wrapper.getSymbol.mockReturnValue("WXDAI");
     const { GithubCommentModule } = await import("../src/parser/github-comment-module");
     githubCommentModule = new GithubCommentModule({
       eventName: "issues.closed",
@@ -83,5 +85,52 @@ describe("GithubCommentModule Simplification Rounding", () => {
 
     expect(bodyContent.raw).toContain("<td>Task Simplification</td><td>1</td><td>1.44</td>");
     expect(bodyContent.raw).not.toContain("1.4400000000000002");
+  });
+
+  it("should explain when the reward token is missing on the configured network", async () => {
+    const { GithubCommentModule } = await import("../src/parser/github-comment-module");
+    const invalidNetworkConfig = structuredClone(cfg);
+    invalidNetworkConfig.rewards.evmNetworkId = 1;
+    web3Mocks.Erc20Wrapper.getSymbol.mockImplementationOnce(async () => {
+      throw Object.assign(new Error('call revert exception; method="symbol()"'), { code: "CALL_EXCEPTION" });
+    });
+    const module = new GithubCommentModule({
+      eventName: "issues.closed",
+      payload: {
+        issue: {
+          html_url: issueUrl,
+          number: 69,
+          state_reason: "completed",
+          assignees: [
+            {
+              id: 1,
+              login: "gentlementlegen",
+            },
+          ],
+        },
+        repository: {
+          name: "conversation-rewards",
+          owner: {
+            login: "ubiquity-os",
+            id: 76412717,
+          },
+        },
+      },
+      config: invalidNetworkConfig,
+    } as unknown as ContextPlugin);
+    const result: Result = {
+      gentlementlegen: {
+        total: 1,
+        userId: 123,
+        permitUrl: "https://pay.ubq.fi",
+        payoutMode: "permit",
+        walletAddress: "0x1",
+        evaluationCommentHtml: "<p>None</p>",
+      },
+    };
+
+    await expect(module.getBodyContent({} as unknown as IssueActivity, result)).rejects.toThrow(
+      "This token 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d was not found on network ID 1"
+    );
   });
 });


### PR DESCRIPTION
Summary:

- Catch ERC-20 `symbol()` call exceptions when reward comment rendering looks up the configured token symbol.
- Replace the cryptic ethers `CALL_EXCEPTION` with a clear token/network mismatch message.
- Add a regression test for an invalid network ID paired with the configured reward token.

Validation:

- `npx prettier --check src\parser\github-comment-module.ts tests\github-comment-simplification-rounding.test.ts`
- `npx jest tests\github-comment-simplification-rounding.test.ts --runInBand` - 2 pass, 0 fail
- `npx tsc --noEmit`
- `git diff --check`

Bounty claim:

- Bounty issue: https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/271
- This PR addresses the requested behavior by replacing the raw ethers `symbol()` failure with `This token 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d was not found on network ID 1`.

Resolves #271