### PR TITLE
fix: cap review rewards to pull request diff

### DIFF
--- a/src/helpers/pull-request-data.ts
+++ b/src/helpers/pull-request-data.ts
@@ -24,6 +24,7 @@ type CommitParent = NonNullable<CommitEdge["node"]["commit"]["parents"]["nodes"]
 export class PullRequestData {
   private readonly _fileMap = new Map<string, PullRequestFile>();
   private _pullCommits: LightweightCommit[] = [];
+  private _pullFileList: PullRequestFile[] | null = null;
 
   constructor(
     private _context: ContextPlugin,
@@ -65,6 +66,40 @@ export class PullRequestData {
 
   public get pullCommits(): ReadonlyArray<LightweightCommit> {
     return this._pullCommits;
+  }
+
+  public async fetchPullFiles(): Promise<ReadonlyArray<PullRequestFile>> {
+    if (this._pullFileList) {
+      return Object.freeze([...this._pullFileList]);
+    }
+
+    const files: PullRequestFile[] = [];
+    let page = 1;
+    let shouldLoop: boolean;
+    do {
+      const response = await this._context.octokit.rest.pulls.listFiles({
+        owner: this._owner,
+        repo: this._repo,
+        pull_number: this._pullNumber,
+        per_page: 100,
+        page,
+      });
+      files.push(
+        ...(response.data ?? []).map((file) => ({
+          filename: file.filename,
+          additions: file.additions ?? 0,
+          deletions: file.deletions ?? 0,
+          status: file.status,
+        }))
+      );
+      shouldLoop = this.shouldContinue(response.headers.link, response.data.length);
+      if (shouldLoop) {
+        page += 1;
+      }
+    } while (shouldLoop);
+
+    this._pullFileList = files;
+    return Object.freeze([...files]);
   }
 
   private async fetchCommitFiles(sha: string) {

--- a/src/parser/review-incentivizer-module.ts
+++ b/src/parser/review-incentivizer-module.ts
@@ -19,6 +19,11 @@ interface CommitDiff {
   };
 }
 
+interface ReviewEffect {
+  addition: number;
+  deletion: number;
+}
+
 export class ReviewIncentivizerModule extends BaseModule {
   private readonly _configuration: ReviewIncentivizerConfiguration | null =
     this.context.config.incentives.reviewIncentivizer;
@@ -115,6 +120,62 @@ export class ReviewIncentivizerModule extends BaseModule {
     return reviewEffect;
   }
 
+  async getReviewablePullRequestDiff(prData: PullRequestData, excludedFilePatterns?: string[] | null) {
+    const reviewEffect = { addition: 0, deletion: 0 };
+    const pullFiles = await prData.fetchPullFiles();
+
+    for (const file of pullFiles) {
+      if (!shouldExcludeFile(file.filename, excludedFilePatterns)) {
+        reviewEffect.addition += file.additions;
+        reviewEffect.deletion += file.deletions;
+      }
+    }
+
+    return reviewEffect;
+  }
+
+  capReviewDiffRewards(reviews: ReviewScore[], maxEffect: ReviewEffect, priority: number): ReviewScore[] {
+    const maxTotal = maxEffect.addition + maxEffect.deletion;
+    const total = reviews.reduce((sum, review) => sum + review.effect.addition + review.effect.deletion, 0);
+    if (total <= maxTotal) {
+      return reviews;
+    }
+
+    let remaining = maxTotal;
+    return reviews.map((review) => {
+      const reviewTotal = review.effect.addition + review.effect.deletion;
+      const limitedEffect = this.limitReviewEffect(review.effect, remaining);
+      remaining = Math.max(0, remaining - reviewTotal);
+      return {
+        ...review,
+        effect: limitedEffect,
+        reward: ((limitedEffect.addition + limitedEffect.deletion) * priority) / this._baseRate,
+      };
+    });
+  }
+
+  private limitReviewEffect(effect: ReviewEffect, maxTotal: number): ReviewEffect {
+    const total = effect.addition + effect.deletion;
+    if (total <= maxTotal) {
+      return effect;
+    }
+
+    if (maxTotal <= 0 || total <= 0) {
+      return { addition: 0, deletion: 0 };
+    }
+
+    let addition = Math.min(effect.addition, Math.floor((effect.addition / total) * maxTotal));
+    let deletion = Math.min(effect.deletion, Math.floor((effect.deletion / total) * maxTotal));
+    let remaining = maxTotal - addition - deletion;
+
+    const extraAddition = Math.min(remaining, effect.addition - addition);
+    addition += extraAddition;
+    remaining -= extraAddition;
+    deletion += Math.min(remaining, effect.deletion - deletion);
+
+    return { addition, deletion };
+  }
+
   async fetchReviewDiffRewards(
     baseOwner: string,
     baseRepo: string,
@@ -175,7 +236,13 @@ export class ReviewIncentivizerModule extends BaseModule {
       }
     }
 
-    return reviews;
+    try {
+      const pullRequestEffect = await this.getReviewablePullRequestDiff(prData, excludedFilePatterns);
+      return this.capReviewDiffRewards(reviews, pullRequestEffect, priority);
+    } catch (e) {
+      this.context.logger.warn("Failed to fetch pull request diff for review reward cap", { e });
+      return reviews;
+    }
   }
 
   get enabled(): boolean {

--- a/tests/review-incentivizer.test.ts
+++ b/tests/review-incentivizer.test.ts
@@ -146,6 +146,42 @@ describe("Review Incentivizer", () => {
     spy.mockClear();
   });
 
+  it("Should cap review rewards to the pull-request diff", async () => {
+    const { ReviewIncentivizerModule } = await import("../src/parser/review-incentivizer-module");
+    const reviewIncentivizerModule = new ReviewIncentivizerModule(ctx);
+
+    const cappedRewards = reviewIncentivizerModule.capReviewDiffRewards(
+      [
+        {
+          reviewId: 1,
+          effect: { addition: 30, deletion: 20 },
+          reward: 0.5,
+          priority: 1,
+        },
+        {
+          reviewId: 2,
+          effect: { addition: 80, deletion: 20 },
+          reward: 1,
+          priority: 1,
+        },
+      ],
+      { addition: 70, deletion: 30 },
+      1
+    );
+
+    expect(cappedRewards[0]).toMatchObject({
+      reviewId: 1,
+      effect: { addition: 30, deletion: 20 },
+      reward: 0.5,
+    });
+    expect(cappedRewards[1]).toMatchObject({
+      reviewId: 2,
+      effect: { addition: 40, deletion: 10 },
+      reward: 0.5,
+    });
+    expect(cappedRewards.reduce((sum, review) => sum + review.effect.addition + review.effect.deletion, 0)).toBe(100);
+  });
+
   it("Should skip removed files in review incentives diff calculation", async () => {
     jest.spyOn(ctx.octokit.rest.repos, "compareCommits").mockImplementationOnce(async () => {
       return {


### PR DESCRIPTION
Fixes #289

## Summary

- Fetch the aggregate pull-request file diff and use it as the maximum reviewable change total.
- Cap cumulative review diff rewards against that PR-level total so merge-history diffs cannot inflate review payouts beyond the actual merged changes.
- Keep existing excluded-file filtering when calculating both the per-review diffs and the PR-level cap.

## Verification

- `npx jest tests/review-incentivizer.test.ts --runInBand --no-coverage`
- `npx tsc --noEmit`
- `npx eslint src/helpers/pull-request-data.ts src/parser/review-incentivizer-module.ts tests/review-incentivizer.test.ts`
- `npx prettier --check src/helpers/pull-request-data.ts src/parser/review-incentivizer-module.ts tests/review-incentivizer.test.ts`
- `npx cspell src/helpers/pull-request-data.ts src/parser/review-incentivizer-module.ts tests/review-incentivizer.test.ts`
- `git diff --check`