### PR TITLE
fix: skip multiline slash command comments

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -50,6 +50,10 @@ export class DataPurgeModule extends BaseModule {
   }
 
   private _cleanCommentBody(body: string): string {
+    if (/^\s*\/\S+/.test(body)) {
+      return "";
+    }
+
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
     return (
       body

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -122,4 +122,14 @@ describe("Purging tests", () => {
     const result = JSON.parse(processor.dump());
     expect(result).toEqual(hiddenCommentPurged);
   });
+
+  it("Should purge multiline slash command comments completely", () => {
+    const dataPurgeModule = new DataPurgeModule(ctx) as unknown as {
+      _cleanCommentBody(body: string): string;
+    };
+
+    expect(
+      dataPurgeModule._cleanCommentBody("/ask\nCheck my scoring.\nhttps://github.com/example/repo/issues/1")
+    ).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #242.

Multiline slash command comments should not be evaluated for conversation rewards. The user extractor already ignores comments that start with `/`, but the data purge step could still leave the multiline command body behind for users already present in the reward result.

## Changes

- Treat comments whose trimmed body starts with a slash command as empty during data purge.
- Preserve the existing cleanup behavior for non-command comments.
- Add focused coverage for a multiline `/ask` command body.

## Validation

- `npx jest --runTestsByPath tests\purging.test.ts --runInBand` passed.
- `npx tsc --noEmit` passed.
- `npx eslint src\parser\data-purge-module.ts tests\purging.test.ts --no-warn-ignored` passed.

