### PR TITLE
fix: purge multiline slash command payloads

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -55,8 +55,8 @@ export class DataPurgeModule extends BaseModule {
       body
         // Remove quoted text
         .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+        // Remove commands such as /start and their multiline payloads
+        .replace(/(^|\n)\s*\/\S[\s\S]*?(?=\n\s*\n|$)/g, "$1")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/parser/data-purge-module.test.ts
+++ b/tests/parser/data-purge-module.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { DataPurgeModule } from "../../src/parser/data-purge-module";
+import type { ContextPlugin } from "../../src/types/plugin-input";
+
+describe("DataPurgeModule", () => {
+  const context = {
+    config: {
+      incentives: {
+        dataPurge: {},
+      },
+    },
+    logger: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    },
+  } as unknown as ContextPlugin;
+
+  it("removes multiline slash commands and their payload", () => {
+    const module = new DataPurgeModule(context);
+    const body = [
+      "This part should still be evaluated.",
+      "",
+      "/ask",
+      "Please summarize the issue.",
+      "This command payload should not be rewarded.",
+    ].join("\n");
+
+    expect(module["_cleanCommentBody"](body)).toBe("This part should still be evaluated.");
+  });
+
+  it("keeps normal paragraphs after a multiline slash command block", () => {
+    const module = new DataPurgeModule(context);
+    const body = [
+      "/ask",
+      "Please summarize the issue.",
+      "",
+      "This separate paragraph is a normal comment.",
+    ].join("\n");
+
+    expect(module["_cleanCommentBody"](body)).toBe("This separate paragraph is a normal comment.");
+  });
+});


### PR DESCRIPTION
Fixes #242.

## Summary
- removes slash command lines together with their multiline payload from reward evaluation input
- preserves normal comments after a blank line following a command block
- adds focused DataPurgeModule coverage for multiline slash commands

## Verification
- `npx jest tests/parser/data-purge-module.test.ts --runInBand`
- `npx tsc --noEmit --pretty false`

Note: local dependency install required `npm install --no-package-lock --legacy-peer-deps --ignore-scripts` because this environment has Node 22 and no bun, while the repo declares Node >=24.11.1 and a bun-based prepare script.