### PR TITLE
feat: add structured output support investigation

### DIFF
--- a/src/OpenRouter/structured-outputs.ts
+++ b/src/OpenRouter/structured-outputs.ts
@@ -1,0 +1,25 @@
+export const STRUCTURED_OUTPUT_MODELS: string[] = [
+  // DeepSeek models on OpenRouter that support structured_outputs
+  // As of June 2026, NO DeepSeek models support structured outputs through OpenRouter.
+  // See: https://openrouter.ai/docs/features/structured-outputs
+  // Checked models:
+  // - deepseek/deepseek-v4-pro: false
+  // - deepseek/deepseek-v4-flash: false  
+  // - deepseek/deepseek-v3.2: false
+  // - deepseek/deepseek-chat-v3-0324: false
+  // - deepseek/deepseek-r1: false
+  // Free models do NOT support this feature.
+];
+
+export function supportsStructuredOutputs(modelId: string): boolean {
+  if (STRUCTURED_OUTPUT_MODELS.length === 0) return false;
+  return STRUCTURED_OUTPUT_MODELS.some((m) => modelId.includes(m));
+}
+
+export function getStructuredOutputConfig(modelId: string): Record<string, unknown> | null {
+  if (!supportsStructuredOutputs(modelId)) return null;
+  return {
+    type: "json_schema" as const,
+    // Schema will be added when models support structured outputs
+  };
+}


### PR DESCRIPTION
Closes #369

## Research Findings

Checked all DeepSeek models on OpenRouter API. **None support structured outputs** at this time.

### Changes
- Added `src/OpenRouter/structured-outputs.ts` with:
  - `supportsStructuredOutputs()` — returns false for all current DeepSeek models
  - `getStructuredOutputConfig()` — ready for when models add support

### Verified models
deepseek/deepseek-v4-pro, deepseek-v4-flash, deepseek-v3.2, deepseek-chat-v3-0324, deepseek-r1 — all `structured_outputs: false`