### PR TITLE
fix: strip multiline slash commands and their content in DataPurgeModule

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -55,8 +55,9 @@ export class DataPurgeModule extends BaseModule {
       body
         // Remove quoted text
         .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+        // Remove commands like /start, /ask etc. and their multiline content
+        // Matches a slash-command line and any following non-empty, non-command lines
+        .replace(/^\/.+(?:\n(?!\n|\/).*)*/gm, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes


### PR DESCRIPTION
## What

Fixes the bug where multiline slash commands (e.g., `/ask` followed by content on subsequent lines) are evaluated as regular comments instead of being fully removed.

## Root Cause

In `DataPurgeModule._cleanCommentBody()`, the regex `/^\/.+/g` was missing the `m` (multiline) flag and only stripped the single line containing the slash command. Content on subsequent lines remained and was incorrectly evaluated.

## Fix

Changed the regex from `/^\/.+/g` to `/^\/.+(?:\n(?!\n|\/).*)*/gm`:

- Added `m` flag so `^` matches the start of each line
- Added `(?:\n(?!\n|\/).*)*` to capture subsequent non-empty, non-command lines as part of the command block
- This ensures both the command line and its content are removed together

Resolves: https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/242
Bounty: https://github.com/devpool-directory/devpool-directory/issues/5873