### PR TITLE
fix: purge multiline slash command content

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -49,14 +49,45 @@ export class DataPurgeModule extends BaseModule {
     return false;
   }
 
+  private _removeSlashCommandBlocks(body: string): string {
+    const lines = body.split(/\r?\n/);
+    const isSlashCommand = (line: string) => /^\s*\/\S/.test(line);
+    const firstContentLine = lines.find((line) => line.trim().length > 0);
+
+    if (firstContentLine && isSlashCommand(firstContentLine)) {
+      return "";
+    }
+
+    const cleanedLines: string[] = [];
+    let skippingCommandBlock = false;
+
+    for (const line of lines) {
+      if (isSlashCommand(line)) {
+        skippingCommandBlock = true;
+        continue;
+      }
+
+      if (skippingCommandBlock) {
+        if (!line.trim()) {
+          skippingCommandBlock = false;
+          cleanedLines.push(line);
+        }
+        continue;
+      }
+
+      cleanedLines.push(line);
+    }
+
+    return cleanedLines.join("\n");
+  }
+
   private _cleanCommentBody(body: string): string {
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+    const withoutQuotedText = body
+      // Remove quoted text
+      .replace(/^>.*$/gm, "");
     return (
-      body
-        // Remove quoted text
-        .replace(/^>.*$/gm, "")
-        // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+      this._removeSlashCommandBlocks(withoutQuotedText)
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -98,6 +98,7 @@ afterAll(() => server.close());
 describe("Purging tests", () => {
   const issue = parseGitHubUrl(issueUrl);
   let activity: IssueActivity;
+  let dataPurgeModule: DataPurgeModule;
 
   beforeEach(async () => {
     drop(db);
@@ -110,6 +111,7 @@ describe("Purging tests", () => {
     const { IssueActivity } = await import("../src/issue-activity");
     activity = new IssueActivity(ctx, issue);
     await activity.init();
+    dataPurgeModule = new DataPurgeModule(ctx);
   });
 
   it("Should purge collapsed comments", async () => {
@@ -121,5 +123,21 @@ describe("Purging tests", () => {
     await processor.run(activity);
     const result = JSON.parse(processor.dump());
     expect(result).toEqual(hiddenCommentPurged);
+  });
+
+  it("Should purge multiline slash command comments", () => {
+    const cleanedBody = (dataPurgeModule as unknown as { _cleanCommentBody(body: string): string })._cleanCommentBody(
+      "/ask\nPlease score this response.\nIt should not be evaluated."
+    );
+
+    expect(cleanedBody).toBe("");
+  });
+
+  it("Should keep normal text while removing a later multiline slash command block", () => {
+    const cleanedBody = (dataPurgeModule as unknown as { _cleanCommentBody(body: string): string })._cleanCommentBody(
+      "This is useful context.\n\n/ask\nIgnore this command payload.\nThis should be removed."
+    );
+
+    expect(cleanedBody).toBe("This is useful context.");
   });
 });


### PR DESCRIPTION
## Summary

Fixes https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/242.

Multiline slash command comments are now removed from the reward evaluation body instead of leaving the command payload behind as normal comment text.

## Changes

- Adds a slash-command block purge step to `DataPurgeModule`.
- Removes a full leading slash command comment, including all following payload lines.
- Removes later slash command blocks while preserving normal comment content before them.
- Adds regression coverage for a whole multiline command comment and for normal text followed by a slash command block.

## Validation

- `prettier --check src/parser/data-purge-module.ts tests/purging.test.ts`
- `git diff --check`
- Direct `DataPurgeModule._cleanCommentBody` assertions with `ts-node/esm`

`jest tests/purging.test.ts --runInBand` was attempted, but the local pnpm/Jest runtime fails on existing ESM transform handling for `@octokit/rest`.
