### PR TITLE
fix: ignore multiline slash command comments

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -51,12 +51,13 @@ export class DataPurgeModule extends BaseModule {
 
   private _cleanCommentBody(body: string): string {
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+    const slashCommandBlockRegex = /^\/[a-z][\w-]*(?:\s[\s\S]*)?$/im;
     return (
       body
         // Remove quoted text
         .replace(/^>.*$/gm, "")
         // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+        .replace(slashCommandBlockRegex, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/purging.test.ts
+++ b/tests/purging.test.ts
@@ -98,6 +98,7 @@ afterAll(() => server.close());
 describe("Purging tests", () => {
   const issue = parseGitHubUrl(issueUrl);
   let activity: IssueActivity;
+  let dataPurgeModule: DataPurgeModule;
 
   beforeEach(async () => {
     drop(db);
@@ -110,6 +111,7 @@ describe("Purging tests", () => {
     const { IssueActivity } = await import("../src/issue-activity");
     activity = new IssueActivity(ctx, issue);
     await activity.init();
+    dataPurgeModule = new DataPurgeModule(ctx);
   });
 
   it("Should purge collapsed comments", async () => {
@@ -121,5 +123,15 @@ describe("Purging tests", () => {
     await processor.run(activity);
     const result = JSON.parse(processor.dump());
     expect(result).toEqual(hiddenCommentPurged);
+  });
+
+  it("Should purge multiline slash command comments", () => {
+    expect(dataPurgeModule["_cleanCommentBody"]("/ask\nPlease score this as a normal comment.")).toBe("");
+  });
+
+  it("Should keep inline slash command references in normal comments", () => {
+    expect(dataPurgeModule["_cleanCommentBody"]("Use `/help` if you need a command list.")).toBe(
+      "Use `/help` if you need a command list."
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Ignore slash command comments that span multiple lines during data purge.
- Keep inline slash command references in normal comments, such as `Use /help`.
- Add regression coverage for multiline slash command purging.

Fixes #242.

## Validation

- `git diff --check`
- Local Node regex check for multiline command removal and inline command preservation

Full Jest was not run locally because this environment does not have `bun`, and `npm install --legacy-peer-deps --ignore-scripts --no-package-lock` hung without producing `node_modules`.