### PR TITLE
Fix token network mismatch error message

### DIFF
--- a/src/parser/github-comment-module.ts
+++ b/src/parser/github-comment-module.ts
@@ -77,7 +77,12 @@ export class GithubCommentModule extends BaseModule {
       return cached;
     }
     const tokenContract = await getContract(config.evmNetworkId, config.erc20RewardToken, ERC20_ABI);
-    const symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    let symbol: string;
+    try {
+      symbol = await new Erc20Wrapper(tokenContract).getSymbol();
+    } catch {
+      throw new Error(`Token ${config.erc20RewardToken} was not found on network ID ${config.evmNetworkId}`);
+    }
     this._tokenSymbolCache.set(key, symbol);
     return symbol;
   }

--- a/tests/github-comment-token-symbol.test.ts
+++ b/tests/github-comment-token-symbol.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { ContextPlugin, RewardSettings } from "../src/types/plugin-input";
+import cfg from "./__mocks__/results/valid-configuration.json";
+import { mockWeb3Module } from "./helpers/web3-mocks";
+
+const web3Mocks = mockWeb3Module();
+
+type TokenSymbolReader = {
+  _getTokenSymbolForConfig(config: RewardSettings): Promise<string>;
+};
+
+describe("GithubCommentModule token symbol lookup", () => {
+  let githubCommentModule: TokenSymbolReader;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const { GithubCommentModule } = await import("../src/parser/github-comment-module");
+    githubCommentModule = new GithubCommentModule({
+      eventName: "issues.closed",
+      payload: {},
+      config: cfg,
+      logger: {
+        debug: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+      },
+    } as unknown as ContextPlugin) as unknown as TokenSymbolReader;
+  });
+
+  it("explains when the configured token is not available on the selected network", async () => {
+    const rewards = {
+      ...(cfg.rewards as RewardSettings),
+      evmNetworkId: 1,
+    };
+
+    const getSymbol = web3Mocks.Erc20Wrapper.getSymbol as unknown as {
+      mockRejectedValueOnce(error: Error): void;
+    };
+    getSymbol.mockRejectedValueOnce(new Error('call revert exception (method="symbol()", data="0x")'));
+
+    await expect(githubCommentModule._getTokenSymbolForConfig(rewards)).rejects.toThrow(
+      "Token 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d was not found on network ID 1"
+    );
+  });
+});


### PR DESCRIPTION
Resolves #271

## Summary

Fixes the unclear token-symbol lookup failure when the configured reward token is not deployed on the selected network.

## Changes

- Wraps token symbol lookup failures with a clear configuration error that includes the token address and network ID.
- Adds regression coverage for the network/token mismatch case.

## Verification

- `bun x jest tests/github-comment-token-symbol.test.ts --runInBand --coverage=false`
- `bun x jest --runInBand --coverage=false`
- `bun x tsc --noEmit`
- `bun x prettier --check src/parser/github-comment-module.ts tests/github-comment-token-symbol.test.ts`
- `bun x eslint src/parser/github-comment-module.ts tests/github-comment-token-symbol.test.ts`
- `bun x cspell src/parser/github-comment-module.ts tests/github-comment-token-symbol.test.ts`
- `bun run build`
