### PR TITLE
fix: skip empty review incentive submissions

### DIFF
--- a/src/parser/review-incentivizer-module.ts
+++ b/src/parser/review-incentivizer-module.ts
@@ -3,7 +3,7 @@ import {
   ReviewIncentivizerConfiguration,
   reviewIncentivizerConfigurationType,
 } from "../configuration/review-incentivizer-config";
-import { GitHubPullRequestReviewState } from "../github-types";
+import { GitHubPullRequestReviewComment, GitHubPullRequestReviewState } from "../github-types";
 import { getExcludedFiles, shouldExcludeFile } from "../helpers/excluded-files";
 import { PullRequestData } from "../helpers/pull-request-data";
 import { IssueActivity } from "../issue-activity";
@@ -57,7 +57,8 @@ export class ReviewIncentivizerModule extends BaseModule {
             baseRef,
             headOwnerRepo ?? "",
             reviewsByUser,
-            priority
+            priority,
+            linkedPullReviews.reviewComments ?? []
           );
           reward.reviewRewards.push({ reviews: reviewDiffs, url: linkedPullReviews.self.html_url });
         }
@@ -121,13 +122,19 @@ export class ReviewIncentivizerModule extends BaseModule {
     baseRef: string,
     headOwnerRepo: string,
     reviewsByUser: GitHubPullRequestReviewState[],
-    priority: number
+    priority: number,
+    reviewComments: GitHubPullRequestReviewComment[] = []
   ) {
     if (reviewsByUser.length == 0) {
       this.context.logger.debug("No reviews found for this pull request", { baseOwner, baseRepo, baseRef });
       return;
     }
     const reviews: ReviewScore[] = [];
+    const substantiveReviews = reviewsByUser.filter((review) => this.isSubstantiveReview(review, reviewComments));
+    if (substantiveReviews.length === 0) {
+      this.context.logger.debug("No substantive reviews found for this pull request", { baseOwner, baseRepo, baseRef });
+      return reviews;
+    }
     const pullNumber = Number(reviewsByUser[0].pull_request_url.split("/").slice(-1)[0]);
 
     const prData = new PullRequestData(this.context, baseOwner, baseRepo, pullNumber);
@@ -139,10 +146,10 @@ export class ReviewIncentivizerModule extends BaseModule {
       throw this.context.logger.error("Could not fetch base commit for this pull request");
     }
     const excludedFilePatterns = await getExcludedFiles(this.context, baseOwner, baseRepo, baseRef);
-    for (const [i, currentReview] of reviewsByUser.entries()) {
+    for (const [i, currentReview] of substantiveReviews.entries()) {
       if (!currentReview.commit_id) continue;
 
-      const previousReview = reviewsByUser[i - 1];
+      const previousReview = substantiveReviews[i - 1];
       const baseSha = previousReview?.commit_id ? previousReview.commit_id : firstCommitSha;
       const headSha = `${headOwnerRepo.replace("/", ":")}:${currentReview.commit_id}`;
 
@@ -176,6 +183,19 @@ export class ReviewIncentivizerModule extends BaseModule {
     }
 
     return reviews;
+  }
+
+  isSubstantiveReview(review: GitHubPullRequestReviewState, reviewComments: GitHubPullRequestReviewComment[]): boolean {
+    if (review.body?.trim()) {
+      return true;
+    }
+
+    return reviewComments.some(
+      (comment) =>
+        comment.pull_request_review_id === review.id &&
+        comment.user?.login === review.user?.login &&
+        Boolean(comment.body?.trim())
+    );
   }
 
   get enabled(): boolean {

--- a/tests/review-incentivizer-substantive.test.ts
+++ b/tests/review-incentivizer-substantive.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { GitHubPullRequestReviewComment, GitHubPullRequestReviewState } from "../src/github-types";
+import { PullRequestData } from "../src/helpers/pull-request-data";
+import { ReviewIncentivizerModule } from "../src/parser/review-incentivizer-module";
+import { ContextPlugin } from "../src/types/plugin-input";
+import cfg from "./__mocks__/results/valid-configuration.json";
+
+const mockGetContent = jest.fn(async () => {
+  const error = new Error("Not Found") as Error & { status?: number };
+  error.status = 404;
+  throw error;
+});
+
+const ctx = {
+  config: cfg,
+  logger: new Logs("debug"),
+  octokit: {
+    rest: {
+      repos: {
+        getContent: mockGetContent,
+      },
+    },
+  },
+} as unknown as ContextPlugin;
+
+function createReview({
+  id,
+  body,
+  commitId,
+  state = "APPROVED",
+}: {
+  id: number;
+  body?: string | null;
+  commitId: string;
+  state?: string;
+}) {
+  return {
+    id,
+    body,
+    commit_id: commitId,
+    state,
+    pull_request_url: "https://api.github.com/repos/owner/repo/pulls/7",
+    user: { login: "reviewer" },
+  } as GitHubPullRequestReviewState;
+}
+
+function createReviewComment(reviewId: number) {
+  return {
+    pull_request_review_id: reviewId,
+    user: { login: "reviewer" },
+    body: "Inline review note",
+  } as GitHubPullRequestReviewComment;
+}
+
+describe("ReviewIncentivizerModule substantive reviews", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockGetContent.mockClear();
+  });
+
+  it("does not reward empty approvals with no review comments", async () => {
+    jest.spyOn(PullRequestData.prototype, "fetchData").mockResolvedValue(undefined);
+    jest
+      .spyOn(PullRequestData.prototype, "pullCommits", "get")
+      .mockReturnValue([{ sha: "first", parents: [{ sha: "base" }], parentCount: 1 }]);
+
+    const reviewIncentivizer = new ReviewIncentivizerModule(ctx);
+    const diffSpy = jest
+      .spyOn(reviewIncentivizer, "getReviewableDiff")
+      .mockResolvedValue({ addition: 5000, deletion: 4000 });
+
+    const result = await reviewIncentivizer.fetchReviewDiffRewards(
+      "owner",
+      "repo",
+      "main",
+      "owner:repo",
+      [createReview({ id: 1, body: "   ", commitId: "approval-commit" })],
+      1,
+      []
+    );
+
+    expect(result).toEqual([]);
+    expect(diffSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps reviews that include either body text or review comments", async () => {
+    jest.spyOn(PullRequestData.prototype, "fetchData").mockResolvedValue(undefined);
+    jest
+      .spyOn(PullRequestData.prototype, "pullCommits", "get")
+      .mockReturnValue([{ sha: "first", parents: [{ sha: "base" }], parentCount: 1 }]);
+
+    const reviewIncentivizer = new ReviewIncentivizerModule(ctx);
+    jest.spyOn(reviewIncentivizer, "getReviewableDiff").mockResolvedValue({ addition: 5, deletion: 3 });
+
+    const result = await reviewIncentivizer.fetchReviewDiffRewards(
+      "owner",
+      "repo",
+      "main",
+      "owner:repo",
+      [createReview({ id: 1, body: "Looks good after checking the changes.", commitId: "body-commit" })],
+      2,
+      []
+    );
+
+    const inlineResult = await reviewIncentivizer.fetchReviewDiffRewards(
+      "owner",
+      "repo",
+      "main",
+      "owner:repo",
+      [createReview({ id: 2, body: "   ", commitId: "inline-commit" })],
+      2,
+      [createReviewComment(2)]
+    );
+
+    expect(result).toEqual([{ reviewId: 1, effect: { addition: 5, deletion: 3 }, reward: 0.16, priority: 2 }]);
+    expect(inlineResult).toEqual([{ reviewId: 2, effect: { addition: 5, deletion: 3 }, reward: 0.16, priority: 2 }]);
+  });
+});


### PR DESCRIPTION
## Summary

Tightens review incentive diff rewards so empty review submissions do not receive code review credit.

- treat reviews with body text as substantive
- treat reviews with matching inline review comments from the same reviewer as substantive
- skip empty approvals/comments with no associated review comments before calculating diff rewards
- keep existing review diff and file exclusion behavior for substantive reviews
- add regression tests for empty approvals and substantive body/inline-review cases

## Verification

- Red test first: empty approval with no review comments received a 90-unit review reward before the fix.
- `node node_modules\jest\bin\jest.js tests\review-incentivizer-substantive.test.ts --runInBand`
- `node node_modules\jest\bin\jest.js tests\review-incentivizer.test.ts tests\file-exclusion.test.ts tests\review-incentivizer-substantive.test.ts --runInBand`
- `node node_modules\jest\bin\jest.js --runInBand`
- `node node_modules\typescript\bin\tsc --noEmit`
- `bun run build`
- `bunx prettier --check src\parser\review-incentivizer-module.ts tests\review-incentivizer-substantive.test.ts`
- `bunx cspell src\parser\review-incentivizer-module.ts tests\review-incentivizer-substantive.test.ts`
- `bunx eslint src\parser\review-incentivizer-module.ts tests\review-incentivizer-substantive.test.ts`

All listed checks passed locally. `bun run build` exits successfully while preserving the repository's existing Windows manifest-formatting warning.

Closes #260