### PR TITLE
fix: downrank relevance scoring meta commentary

### DIFF
--- a/src/parser/content-evaluator-module.ts
+++ b/src/parser/content-evaluator-module.ts
@@ -628,6 +628,8 @@ export class ContentEvaluatorModule extends BaseModule {
         - Relation to the issue description
         - Connection to other comments
         - Contribution to issue resolution
+        - Treat meta commentary about the reward or relevance evaluator as not task-relevant by itself
+        - Comments about scoring quality, saving the conversation as a test case, or improving this evaluator should score 0.0 unless it includes a concrete proposal for the issue itself
       5. Handle GitHub-flavored markdown:
         - Ignore text beginning with '>' as it references another comment
         - Distinguish between referenced text and the commenter's own words

--- a/tests/parser/content-evaluator-module.test.ts
+++ b/tests/parser/content-evaluator-module.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { ContentEvaluatorModule } from "../../src/parser/content-evaluator-module";
+import { ContextPlugin } from "../../src/types/plugin-input";
+
+function createModule() {
+  return new ContentEvaluatorModule({
+    config: {
+      incentives: {
+        contentEvaluator: {},
+      },
+    },
+    logger: {
+      warn: jest.fn(),
+      fatal: jest.fn(),
+    },
+    payload: {
+      issue: {},
+    },
+  } as unknown as ContextPlugin);
+}
+
+describe("ContentEvaluatorModule", () => {
+  it("guides issue comment scoring to downrank meta discussion about the evaluator", () => {
+    const module = createModule();
+
+    const prompt = module._generatePromptForComments(
+      "Build a vector search feature for issue comments.",
+      "gentlementlegen",
+      [
+        {
+          id: 1,
+          author: "gentlementlegen",
+          comment: "Relevance scoring could have done so much better here for you @gentlementlegen",
+        },
+        {
+          id: 2,
+          author: "gentlementlegen",
+          comment:
+            "Perhaps this conversation should be saved as a unit test of sorts so that we can improve the relevance scoring prompt",
+        },
+        {
+          id: 3,
+          author: "maintainer",
+          comment: "The implementation should compare comments to the vector search feature request.",
+        },
+      ]
+    );
+
+    expect(prompt).toContain("meta commentary about the reward or relevance evaluator");
+    expect(prompt).toContain("score 0.0 unless it includes a concrete proposal for the issue itself");
+  });
+});


### PR DESCRIPTION
## Summary

Refines the issue-comment relevance scoring prompt so comments about the scoring system itself are not treated as task-relevant by default.

The added guidance tells the evaluator to:

- treat meta commentary about the reward or relevance evaluator as not task-relevant by itself
- score comments about scoring quality, saving the conversation as a test case, or improving the evaluator as `0.0` unless they include a concrete proposal for the issue itself

## Files

- `src/parser/content-evaluator-module.ts`
- `tests/parser/content-evaluator-module.test.ts`

## Verification

The test was added first and failed on the existing implementation because the prompt did not include the meta-commentary downrank instruction.

After the implementation, the following commands passed:

```powershell
npx.cmd jest --config jest.config.ts tests/parser/content-evaluator-module.test.ts --runInBand
npx.cmd jest --config jest.config.ts tests/parser/content-evaluator-module.test.ts tests/process.issue.test.ts tests/rewards.test.ts --runInBand
npx.cmd prettier --check src/parser/content-evaluator-module.ts tests/parser/content-evaluator-module.test.ts
npx.cmd eslint src/parser/content-evaluator-module.ts tests/parser/content-evaluator-module.test.ts
bun.cmd run build
```

Build note: `bun run build` emitted the repository tool warning `Could not format manifest with Prettier: spawn EINVAL`, then completed successfully and generated `dist`.

Closes #223