### PR TITLE
fix: ignore multiline slash command payloads

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -51,12 +51,14 @@ export class DataPurgeModule extends BaseModule {
 
   private _cleanCommentBody(body: string): string {
     const urlRegex = /(?<!]\(|["'=])(https?:\/\/[^\s<>"'\]]+)(?!\)|["'])/gi;
+    const bodyWithoutQuotedText = body.replace(/^>.*$/gm, "");
+    if (bodyWithoutQuotedText.trimStart().startsWith("/")) {
+      return "";
+    }
     return (
-      body
-        // Remove quoted text
-        .replace(/^>.*$/gm, "")
+      bodyWithoutQuotedText
         // Remove commands such as /start
-        .replace(/^\/.+/g, "")
+        .replace(/^\/.+$/gm, "")
         // Remove HTML comments
         .replace(/<!--[\s\S]*?-->/g, "")
         // Remove the footnotes

--- a/tests/data-purge-command.test.ts
+++ b/tests/data-purge-command.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { DataPurgeModule } from "../src/parser/data-purge-module";
+import { ContextPlugin } from "../src/types/plugin-input";
+
+function createContext(): ContextPlugin {
+  return {
+    config: {
+      incentives: {
+        dataPurge: {
+          skipCommentsWhileAssigned: "none",
+        },
+      },
+    },
+    logger: {
+      debug: jest.fn(),
+      warn: jest.fn((message: string) => new Error(message)),
+    },
+  } as unknown as ContextPlugin;
+}
+
+describe("DataPurgeModule command cleanup", () => {
+  it("removes a multiline slash command and its payload from rewardable content", () => {
+    const module = new DataPurgeModule(createContext());
+
+    const cleaned = module["_cleanCommentBody"](
+      "/ask\nPlease evaluate this implementation.\nThis prompt is command input."
+    );
+
+    expect(cleaned).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Updates comment cleaning so that a multiline slash command and its payload are removed from rewardable content.

## Changes

- removes quoted text before command detection
- treats a comment whose effective body starts with `/` as command input and returns no rewardable content
- keeps the existing cleanup pipeline for normal non-command comments
- removes standalone command lines with multiline matching when they appear inside otherwise normal comments

## Verification

Passed locally:

- Red check before implementation: `npx.cmd jest tests/data-purge-command.test.ts --runInBand` failed because the old cleaner kept the multiline command payload
- Green check: `npx.cmd jest tests/data-purge-command.test.ts --runInBand`
- Related tests: `npx.cmd jest tests/data-purge-command.test.ts tests/process.issue.test.ts tests/rewards.test.ts --runInBand`
- Full tests: `npx.cmd jest --runInBand --silent`
- Formatting: `npx.cmd prettier --check src/parser/data-purge-module.ts tests/data-purge-command.test.ts`
- Static check: `npx.cmd eslint src/parser/data-purge-module.ts tests/data-purge-command.test.ts`
- Build: `bun.cmd run build`

Build note: `bun.cmd run build` emitted the existing warning `Could not format manifest with Prettier: spawn EINVAL`, then completed with exit code 0.

Closes #242