### PR TITLE
fix: keep previous assignee research comments

### DIFF
--- a/src/parser/data-purge-module.ts
+++ b/src/parser/data-purge-module.ts
@@ -1,4 +1,4 @@
-import { CommentAssociation } from "../configuration/comment-types";
+import { CommentAssociation, CommentKind } from "../configuration/comment-types";
 import { DataPurgeConfiguration } from "../configuration/data-purge-config";
 import { GitHubPullRequestReviewComment } from "../github-types";
 import { getAssignmentPeriods, isCommentDuringAssignment, UserAssignments } from "../helpers/user-assigned-timespan";
@@ -24,6 +24,17 @@ export class DataPurgeModule extends BaseModule {
     return true;
   }
 
+  private _isCurrentIssueAssignee(login?: string) {
+    if (!login || !("issue" in this.context.payload)) {
+      return false;
+    }
+    return this.context.payload.issue.assignees?.some((assignee) => assignee?.login === login) ?? false;
+  }
+
+  private _shouldKeepAssignedIssueComment(comment: CommentType) {
+    return Boolean(comment.commentType & CommentKind.ISSUE) && !this._isCurrentIssueAssignee(comment.user?.login);
+  }
+
   async _shouldSkipComment(comment: Awaited<ReturnType<IssueActivity["getAllComments"]>>[0]) {
     if ("isMinimized" in comment && comment.isMinimized) {
       this.context.logger.debug("Skipping hidden comment", { comment });
@@ -40,6 +51,9 @@ export class DataPurgeModule extends BaseModule {
         this._configuration.skipCommentsWhileAssigned === "exact"
       )
     ) {
+      if (this._shouldKeepAssignedIssueComment(comment)) {
+        return false;
+      }
       this.context.logger.debug("Skipping comment during assignment", {
         body: comment.body?.replace(/(.{100})..+/, "$1…"),
         url: comment.html_url,

--- a/tests/parser/data-purge-module.test.ts
+++ b/tests/parser/data-purge-module.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { CommentAssociation, CommentKind } from "../../src/configuration/comment-types";
+import { DataPurgeModule } from "../../src/parser/data-purge-module";
+import { ContextPlugin } from "../../src/types/plugin-input";
+
+function createModule() {
+  const module = new DataPurgeModule({
+    config: {
+      incentives: {
+        dataPurge: {
+          skipCommentsWhileAssigned: "all",
+        },
+      },
+    },
+    logger: {
+      debug: jest.fn(),
+      warn: jest.fn(),
+    },
+    payload: {
+      issue: {
+        html_url: "https://github.com/owner/repo/issues/1",
+        assignees: [{ login: "current-assignee" }],
+      },
+    },
+  } as unknown as ContextPlugin);
+
+  module._assignmentPeriods = {
+    "previous-assignee": [
+      {
+        assignedAt: "2026-01-01T00:00:00.000Z",
+        unassignedAt: "2026-01-03T00:00:00.000Z",
+      },
+    ],
+    "current-assignee": [
+      {
+        assignedAt: "2026-01-01T00:00:00.000Z",
+        unassignedAt: null,
+      },
+    ],
+  };
+
+  return module;
+}
+
+function createComment(login: string, commentType: CommentKind | CommentAssociation, id = 1) {
+  return {
+    id,
+    body: "Research notes with useful implementation context.",
+    created_at: "2026-01-02T00:00:00.000Z",
+    html_url: "https://github.com/owner/repo/issues/1#issuecomment-1",
+    user: {
+      id,
+      login,
+      type: "User",
+    },
+    commentType,
+  } as Parameters<DataPurgeModule["_shouldSkipComment"]>[0];
+}
+
+describe("DataPurgeModule", () => {
+  it("keeps issue research from previous assignees without crediting current assignees or pull-request work", async () => {
+    const module = createModule();
+
+    await expect(
+      module._shouldSkipComment(createComment("previous-assignee", CommentKind.ISSUE | CommentAssociation.ASSIGNEE))
+    ).resolves.toBe(false);
+    await expect(
+      module._shouldSkipComment(createComment("current-assignee", CommentKind.ISSUE | CommentAssociation.ASSIGNEE, 2))
+    ).resolves.toBe(true);
+    await expect(
+      module._shouldSkipComment(createComment("previous-assignee", CommentKind.PULL | CommentAssociation.ASSIGNEE, 3))
+    ).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adjusts comment purging around assignment windows:

- Previous assignees can keep issue discussion/research comments made while they were assigned.
- Current issue assignees at completion are still filtered for assignment-window issue comments.
- Pull-request related comments from previous assignees remain filtered, so work/review discussion on their pull requests is not credited.

## Files

- `src/parser/data-purge-module.ts`
- `tests/parser/data-purge-module.test.ts`

## Verification

The test was added first and failed on the existing implementation:

```text
Expected: false
Received: true
```

After the implementation, the following commands passed:

```powershell
npx.cmd jest --config jest.config.ts tests/parser/data-purge-module.test.ts --runInBand
npx.cmd jest --config jest.config.ts tests/parser/data-purge-module.test.ts tests/purging.test.ts tests/process.issue.test.ts --runInBand
npx.cmd prettier --check src/parser/data-purge-module.ts tests/parser/data-purge-module.test.ts
npx.cmd eslint src/parser/data-purge-module.ts tests/parser/data-purge-module.test.ts
bun.cmd run build
```

Build note: `bun run build` emitted the repository tool warning `Could not format manifest with Prettier: spawn EINVAL`, then completed successfully and generated `dist`.

Closes #296