### PR TITLE
fix: clarify missing token contract errors

### DIFF
--- a/src/helpers/web3.ts
+++ b/src/helpers/web3.ts
@@ -12,6 +12,10 @@ export interface BatchTransferPermit {
   signature: string;
   transfers: { to: string; requestedAmount: BigNumberish }[];
 }
+export interface Erc20ContractContext {
+  networkId?: number;
+  tokenAddress?: string;
+}
 // Required ERC20 ABI functions
 export const ERC20_ABI = [
   "function symbol() view returns (string)",
@@ -48,14 +52,43 @@ export async function getEvmWallet(privateKey: string, provider: ethers.provider
 }
 
 export class Erc20Wrapper {
-  constructor(private _contract: Contract) {}
+  constructor(
+    private _contract: Contract,
+    private _context: Erc20ContractContext = {}
+  ) {}
+
+  private _isContractCallException(error: unknown) {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "CALL_EXCEPTION"
+    );
+  }
+
+  private async _getNetworkId() {
+    if (this._context.networkId !== undefined) {
+      return this._context.networkId;
+    }
+    const network = await this._contract.provider.getNetwork();
+    return network.chainId;
+  }
 
   /**
    * Returns ERC20 token symbol
    * @returns ERC20 token symbol
    */
   async getSymbol() {
-    return await this._contract.symbol();
+    try {
+      return await this._contract.symbol();
+    } catch (e) {
+      if (!this._isContractCallException(e)) {
+        throw e;
+      }
+      const tokenAddress = this._context.tokenAddress ?? this._contract.address;
+      const networkId = await this._getNetworkId();
+      throw new Error(`This token \`${tokenAddress}\` was not found on network ID \`${networkId}\`.`);
+    }
   }
 
   /**

--- a/src/helpers/web3.ts
+++ b/src/helpers/web3.ts
@@ -70,8 +70,12 @@ export class Erc20Wrapper {
     if (this._context.networkId !== undefined) {
       return this._context.networkId;
     }
-    const network = await this._contract.provider.getNetwork();
-    return network.chainId;
+    try {
+      const network = await this._contract.provider.getNetwork();
+      return network.chainId;
+    } catch {
+      return "unknown";
+    }
   }
 
   /**
@@ -86,6 +90,10 @@ export class Erc20Wrapper {
         throw e;
       }
       const tokenAddress = this._context.tokenAddress ?? this._contract.address;
+      const contractCode = await this._contract.provider.getCode(tokenAddress);
+      if (contractCode !== "0x") {
+        throw e;
+      }
       const networkId = await this._getNetworkId();
       throw new Error(`This token \`${tokenAddress}\` was not found on network ID \`${networkId}\`.`);
     }

--- a/tests/helpers/web3.test.ts
+++ b/tests/helpers/web3.test.ts
@@ -55,6 +55,23 @@ describe("web3.ts", () => {
     expect(tokenBalance).toEqual(BigNumber.from("1000"));
   }, 120000);
 
+  it("Should explain when a token contract is missing on the selected network", async () => {
+    const tokenAddress = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
+    const missingTokenContract = {
+      address: tokenAddress,
+      symbol: jest.fn().mockRejectedValue(Object.assign(new Error("call revert exception"), { code: "CALL_EXCEPTION" })),
+      provider: mockProvider,
+    };
+    const wrapper = new Erc20Wrapper(missingTokenContract as unknown as ethers.Contract, {
+      networkId: 1,
+      tokenAddress,
+    });
+
+    await expect(wrapper.getSymbol()).rejects.toThrow(
+      `This token \`${tokenAddress}\` was not found on network ID \`1\`.`
+    );
+  }, 120000);
+
   it("Should return correct wallet address", async () => {
     const evmWallet = await getEvmWallet(
       "100958e64966448354216e91d4d4b9418c3fa0cb0a21b935535ced1df8145a0e",

--- a/tests/helpers/web3.test.ts
+++ b/tests/helpers/web3.test.ts
@@ -13,8 +13,14 @@ import {
 } from "../../src/helpers/web3";
 
 class MockProvider extends ethers.providers.BaseProvider {
+  contractCode = "0x1234";
+
   async getNetwork(): Promise<ethers.providers.Network> {
     return this.network;
+  }
+
+  async getCode(): Promise<string> {
+    return this.contractCode;
   }
 }
 
@@ -57,6 +63,7 @@ describe("web3.ts", () => {
 
   it("Should explain when a token contract is missing on the selected network", async () => {
     const tokenAddress = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
+    mockProvider.contractCode = "0x";
     const missingTokenContract = {
       address: tokenAddress,
       symbol: jest.fn().mockRejectedValue(Object.assign(new Error("call revert exception"), { code: "CALL_EXCEPTION" })),
@@ -70,6 +77,35 @@ describe("web3.ts", () => {
     await expect(wrapper.getSymbol()).rejects.toThrow(
       `This token \`${tokenAddress}\` was not found on network ID \`1\`.`
     );
+  }, 120000);
+
+  it("Should explain missing token contracts using provider metadata when context is absent", async () => {
+    const tokenAddress = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
+    mockProvider.contractCode = "0x";
+    const missingTokenContract = {
+      address: tokenAddress,
+      symbol: jest.fn().mockRejectedValue(Object.assign(new Error("call revert exception"), { code: "CALL_EXCEPTION" })),
+      provider: mockProvider,
+    };
+    const wrapper = new Erc20Wrapper(missingTokenContract as unknown as ethers.Contract);
+
+    await expect(wrapper.getSymbol()).rejects.toThrow(
+      `This token \`${tokenAddress}\` was not found on network ID \`100\`.`
+    );
+  }, 120000);
+
+  it("Should preserve call exceptions from existing token contracts", async () => {
+    const tokenAddress = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
+    const callException = Object.assign(new Error("symbol reverted"), { code: "CALL_EXCEPTION" });
+    mockProvider.contractCode = "0x1234";
+    const existingTokenContract = {
+      address: tokenAddress,
+      symbol: jest.fn().mockRejectedValue(callException),
+      provider: mockProvider,
+    };
+    const wrapper = new Erc20Wrapper(existingTokenContract as unknown as ethers.Contract);
+
+    await expect(wrapper.getSymbol()).rejects.toBe(callException);
   }, 120000);
 
   it("Should return correct wallet address", async () => {


### PR DESCRIPTION
Resolves #271

## Summary
- Adds context-aware handling for ERC20 `symbol()` call exceptions.
- Verifies the token address has no deployed contract code before returning a missing-token message.
- Preserves original call exceptions for existing token contracts so real reverts are not masked.
- Adds focused unit tests for the missing-token path, provider metadata fallback, and existing-contract revert path.

## Testing
- `bun run jest:test -- tests/helpers/web3.test.ts`