### PR TITLE
feat: prefund new bounty hunters from faucet

### DIFF
--- a/src/helpers/faucet.test.ts
+++ b/src/helpers/faucet.test.ts
@@ -1,0 +1,16 @@
+import { prefundWalletWithFaucet } from "./faucet";
+
+describe("prefundWalletWithFaucet", () => {
+  it("posts the beneficiary address to the faucet worker", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({} as Response);
+
+    await prefundWalletWithFaucet("0xabc123", "https://example.test", fetchMock as unknown as typeof fetch);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+
+    expect(url).toBeInstanceOf(URL);
+    expect(url.toString()).toBe("https://example.test/?address=0xabc123");
+    expect(init).toEqual({ method: "POST" });
+  });
+});

--- a/src/helpers/faucet.ts
+++ b/src/helpers/faucet.ts
@@ -1,0 +1,12 @@
+const DEFAULT_FAUCET_URL = "https://ubq-faucet.workers.dev";
+
+export async function prefundWalletWithFaucet(
+  address: string,
+  faucetBaseUrl: string = process.env.FAUCET_URL ?? DEFAULT_FAUCET_URL,
+  fetchImpl: typeof fetch = fetch
+) {
+  const faucetUrl = new URL("/", faucetBaseUrl);
+  faucetUrl.searchParams.set("address", address);
+
+  return fetchImpl(faucetUrl, { method: "POST" });
+}

--- a/src/parser/payment-module.ts
+++ b/src/parser/payment-module.ts
@@ -21,6 +21,7 @@ import { BigNumber, ethers, utils } from "ethers";
 import type { Database } from "../adapters/supabase/types/database";
 import { PaymentConfiguration, paymentConfigurationType } from "../configuration/payment-configuration";
 import { isAdmin, isCollaborative } from "../helpers/checkers";
+import { prefundWalletWithFaucet } from "../helpers/faucet";
 import { getUserRewardRole } from "../helpers/permissions";
 import { isGlobalRewardSettings, resolveRewardSettingsForRole, rewardConfigKey } from "../helpers/reward-settings";
 import {
@@ -307,6 +308,22 @@ export class PaymentModule extends BaseModule {
         result[username].permitUrl = `https://pay.ubq.fi?claim=${encodePermits(permits)}`;
         result[username].payoutMode = "permit";
         await this._savePermitsToDatabase(result[username], { issueUrl: payload.issueUrl, issueId }, permits);
+
+        if (reward.walletAddress) {
+          try {
+            await prefundWalletWithFaucet(reward.walletAddress);
+            this.context.logger.info("Requested faucet prefund for new permit recipient", {
+              username,
+              walletAddress: reward.walletAddress,
+            });
+          } catch (e) {
+            this.context.logger.warn("Failed to request faucet prefund", {
+              username,
+              walletAddress: reward.walletAddress,
+              e,
+            });
+          }
+        }
       }
     }
 
@@ -362,7 +379,9 @@ export class PaymentModule extends BaseModule {
   }
 
   _getNetworkExplorer(networkId: number): string {
-    const chain = chains.find((chain) => chain.chainId === networkId);
+    const chain = (chains as Array<{ chainId: number; explorers?: { url: string }[] }>).find(
+      (chain) => chain.chainId === networkId
+    );
     return chain?.explorers?.[0].url || "https://blockscan.com";
   }
 


### PR DESCRIPTION
Add a best-effort faucet call after saving a permit so new bounty hunters can get gas for their first claim.

What changed:
- add a small faucet helper that posts the beneficiary address to the worker
- call the faucet after permit persistence, when the wallet address is already known
- keep permit generation moving even if the faucet request fails
- add a focused unit test for the faucet request shape

Validation:
- `npx jest src/helpers/faucet.test.ts --runInBand`
- `npx tsc -p tsconfig.json --noEmit`

Related bounty request: ubiquity/ubiquibot#893