### PR TITLE
fix: ignore multiline slash command comments

### DIFF
--- a/src/helpers/comment-command.ts
+++ b/src/helpers/comment-command.ts
@@ -1,0 +1,5 @@
+const SLASH_COMMAND_REGEX = /^\/[A-Za-z][\w-]*(?:\s|$)/;
+
+export function isSlashCommandComment(body: string | null | undefined): boolean {
+  return SLASH_COMMAND_REGEX.test(body?.trimStart() ?? "");
+}

--- a/src/issue-activity.ts
+++ b/src/issue-activity.ts
@@ -14,6 +14,7 @@ import {
   GitHubPullRequestReviewState,
 } from "./github-types";
 import { areLoginsEquivalent } from "./helpers/github";
+import { isSlashCommandComment } from "./helpers/comment-command";
 import { isPullRequestEvent } from "./helpers/type-assertions";
 import {
   getIssue,
@@ -247,18 +248,20 @@ export class IssueActivity {
         commentType: CommentKind | CommentAssociation;
         timestamp: string;
       }
-    > = this.comments.map((comment) => {
-      this._addAnchorToUrl(comment);
-      return {
-        ...comment,
-        timestamp: comment.created_at,
-        commentType: this._getTypeFromComment(
-          this.self?.pull_request ? CommentKind.PULL : CommentKind.ISSUE,
-          comment,
-          this.self
-        ),
-      };
-    });
+    > = this.comments
+      .filter((comment) => !isSlashCommandComment(comment.body))
+      .map((comment) => {
+        this._addAnchorToUrl(comment);
+        return {
+          ...comment,
+          timestamp: comment.created_at,
+          commentType: this._getTypeFromComment(
+            this.self?.pull_request ? CommentKind.PULL : CommentKind.ISSUE,
+            comment,
+            this.self
+          ),
+        };
+      });
     if (this.self) {
       const c: GitHubIssue = this.self;
       this._addAnchorToUrl(c);

--- a/tests/issue-activity-command-comments.test.ts
+++ b/tests/issue-activity-command-comments.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { IssueActivity } from "../src/issue-activity";
+import { parseGitHubUrl } from "../src/start";
+import type { ContextPlugin } from "../src/types/plugin-input";
+import cfg from "./__mocks__/results/valid-configuration.json";
+
+describe("IssueActivity command comments", () => {
+  it("excludes multiline slash command comments from reward evaluation", async () => {
+    const issueUrl = "https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/242";
+    const activity = new IssueActivity(
+      {
+        eventName: "issues.closed",
+        config: cfg,
+        logger: new Logs("debug"),
+      } as unknown as ContextPlugin,
+      parseGitHubUrl(issueUrl)
+    );
+
+    activity.self = {
+      id: 242,
+      html_url: issueUrl,
+      created_at: "2026-01-01T00:00:00Z",
+      user: { id: 1 },
+    } as typeof activity.self;
+    activity.comments = [
+      {
+        id: 1,
+        html_url: `${issueUrl}#issuecomment-1`,
+        created_at: "2026-01-01T00:01:00Z",
+        body: "/ask\n\nPlease explain the scoring for this issue.",
+        user: { id: 2 },
+        author_association: "CONTRIBUTOR",
+      },
+      {
+        id: 2,
+        html_url: `${issueUrl}#issuecomment-2`,
+        created_at: "2026-01-01T00:02:00Z",
+        body: "This implementation detail should still be evaluated.",
+        user: { id: 3 },
+        author_association: "CONTRIBUTOR",
+      },
+    ] as typeof activity.comments;
+
+    const comments = await activity.getAllComments();
+
+    expect(comments.map((comment) => comment.id)).toEqual([2, 242]);
+    expect(comments.map((comment) => "body" in comment && comment.body)).not.toContain(
+      "/ask\n\nPlease explain the scoring for this issue."
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Exclude issue comments that are slash commands from reward evaluation.
- Treat multiline commands such as `/ask\n\n...` as commands, not rewardable discussion comments.
- Keep normal discussion comments and issue specifications in the collected activity.
- Add regression coverage for multiline slash command comments.

Closes #242

## Tests

- `node node_modules\jest\bin\jest.js tests\issue-activity-command-comments.test.ts --runInBand --no-coverage`
- `node node_modules\jest\bin\jest.js tests\get-activity.test.ts tests\issue-activity-command-comments.test.ts --runInBand --no-coverage`
- `node node_modules\typescript\bin\tsc --noEmit`
- `node node_modules\eslint\bin\eslint.js src\helpers\comment-command.ts src\issue-activity.ts tests\issue-activity-command-comments.test.ts`
- `node node_modules\prettier\bin\prettier.cjs --check src\helpers\comment-command.ts src\issue-activity.ts tests\issue-activity-command-comments.test.ts`
- `node node_modules\cspell\bin.mjs src\helpers\comment-command.ts src\issue-activity.ts tests\issue-activity-command-comments.test.ts`
- `git diff --check`

Notes:

- `src/types/rpcs.json` was generated locally as an ignored file for TypeScript validation.
- `@swc/core` was installed locally as a Jest peer dependency for validation; it is not part of this patch.