### PR TITLE
fix: ignore multiline slash command comments

### DIFF
--- a/src/helpers/comment-command.ts
+++ b/src/helpers/comment-command.ts
@@ -1,0 +1,5 @@
+const SLASH_COMMAND_REGEX = /^\/[A-Za-z][\w-]*(?:\s|$)/;
+
+export function isSlashCommandComment(body: string | null | undefined): boolean {
+  return SLASH_COMMAND_REGEX.test(body?.trimStart() ?? "");
+}

--- a/src/issue-activity.ts
+++ b/src/issue-activity.ts
@@ -14,6 +14,7 @@ import {
   GitHubPullRequestReviewState,
 } from "./github-types";
 import { areLoginsEquivalent } from "./helpers/github";
+import { isSlashCommandComment } from "./helpers/comment-command";
 import { isPullRequestEvent } from "./helpers/type-assertions";
 import {
   getIssue,
@@ -247,18 +248,20 @@ export class IssueActivity {
         commentType: CommentKind | CommentAssociation;
         timestamp: string;
       }
-    > = this.comments.map((comment) => {
-      this._addAnchorToUrl(comment);
-      return {
-        ...comment,
-        timestamp: comment.created_at,
-        commentType: this._getTypeFromComment(
-          this.self?.pull_request ? CommentKind.PULL : CommentKind.ISSUE,
-          comment,
-          this.self
-        ),
-      };
-    });
+    > = this.comments
+      .filter((comment) => !isSlashCommandComment(comment.body))
+      .map((comment) => {
+        this._addAnchorToUrl(comment);
+        return {
+          ...comment,
+          timestamp: comment.created_at,
+          commentType: this._getTypeFromComment(
+            this.self?.pull_request ? CommentKind.PULL : CommentKind.ISSUE,
+            comment,
+            this.self
+          ),
+        };
+      });
     if (this.self) {
       const c: GitHubIssue = this.self;
       this._addAnchorToUrl(c);

--- a/src/issue-activity.ts
+++ b/src/issue-activity.ts
@@ -198,6 +198,9 @@ export class IssueActivity {
     for (const value of Object.values(linkedPullRequest)) {
       if (Array.isArray(value)) {
         for (const review of value) {
+          if ("body" in review && isSlashCommandComment(review.body)) {
+            continue;
+          }
           this._addAnchorToUrl(review);
           comments.push({
             ...review,

--- a/tests/issue-activity-command-comments.test.ts
+++ b/tests/issue-activity-command-comments.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@jest/globals";
+import { Logs } from "@ubiquity-os/ubiquity-os-logger";
+import { IssueActivity } from "../src/issue-activity";
+import { parseGitHubUrl } from "../src/start";
+import type { ContextPlugin } from "../src/types/plugin-input";
+import cfg from "./__mocks__/results/valid-configuration.json";
+
+describe("IssueActivity command comments", () => {
+  it("excludes multiline slash command comments from reward evaluation", async () => {
+    const issueUrl = "https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/242";
+    const activity = new IssueActivity(
+      {
+        eventName: "issues.closed",
+        config: cfg,
+        logger: new Logs("debug"),
+      } as unknown as ContextPlugin,
+      parseGitHubUrl(issueUrl)
+    );
+
+    activity.self = {
+      id: 242,
+      html_url: issueUrl,
+      created_at: "2026-01-01T00:00:00Z",
+      user: { id: 1 },
+    } as typeof activity.self;
+    activity.comments = [
+      {
+        id: 1,
+        html_url: `${issueUrl}#issuecomment-1`,
+        created_at: "2026-01-01T00:01:00Z",
+        body: "/ask\n\nPlease explain the scoring for this issue.",
+        user: { id: 2 },
+        author_association: "CONTRIBUTOR",
+      },
+      {
+        id: 2,
+        html_url: `${issueUrl}#issuecomment-2`,
+        created_at: "2026-01-01T00:02:00Z",
+        body: "This implementation detail should still be evaluated.",
+        user: { id: 3 },
+        author_association: "CONTRIBUTOR",
+      },
+    ] as typeof activity.comments;
+
+    const comments = await activity.getAllComments();
+
+    expect(comments.map((comment) => comment.id)).toEqual([2, 242]);
+    expect(comments.map((comment) => "body" in comment && comment.body)).not.toContain(
+      "/ask\n\nPlease explain the scoring for this issue."
+    );
+  });
+});

--- a/tests/issue-activity-command-comments.test.ts
+++ b/tests/issue-activity-command-comments.test.ts
@@ -49,4 +49,64 @@ describe("IssueActivity command comments", () => {
       "/ask\n\nPlease explain the scoring for this issue."
     );
   });
+
+  it("excludes multiline slash command comments from linked pull request comments", async () => {
+    const pullUrl = "https://github.com/ubiquity-os-marketplace/text-conversation-rewards/pull/242";
+    const activity = new IssueActivity(
+      {
+        eventName: "pull_request.closed",
+        config: cfg,
+        logger: new Logs("debug"),
+        payload: {
+          pull_request: { html_url: pullUrl },
+        },
+      } as unknown as ContextPlugin,
+      parseGitHubUrl(pullUrl)
+    );
+
+    activity.self = {
+      id: 242,
+      html_url: pullUrl,
+      created_at: "2026-01-01T00:00:00Z",
+      user: { id: 1 },
+      pull_request: { html_url: pullUrl },
+    } as typeof activity.self;
+    activity.linkedMergedPullRequests = [
+      {
+        self: {
+          id: 242,
+          html_url: pullUrl,
+          created_at: "2026-01-01T00:00:00Z",
+          user: { id: 1 },
+        },
+        reviews: [],
+        reviewComments: [],
+        comments: [
+          {
+            id: 1,
+            html_url: `${pullUrl}#issuecomment-1`,
+            created_at: "2026-01-01T00:01:00Z",
+            body: "/ask\n\nPlease explain the scoring for this pull request.",
+            user: { id: 2 },
+            author_association: "CONTRIBUTOR",
+          },
+          {
+            id: 2,
+            html_url: `${pullUrl}#issuecomment-2`,
+            created_at: "2026-01-01T00:02:00Z",
+            body: "This pull request implementation detail should still be evaluated.",
+            user: { id: 3 },
+            author_association: "CONTRIBUTOR",
+          },
+        ],
+      },
+    ] as unknown as typeof activity.linkedMergedPullRequests;
+
+    const comments = await activity.getAllComments(true);
+
+    expect(comments.map((comment) => comment.id)).toEqual([242, 2]);
+    expect(comments.map((comment) => "body" in comment && comment.body)).not.toContain(
+      "/ask\n\nPlease explain the scoring for this pull request."
+    );
+  });
 });


### PR DESCRIPTION
Resolves #242

## Summary

- Exclude issue comments that are slash commands from reward evaluation.
- Treat multiline commands such as `/ask\n\n...` as commands, not rewardable discussion comments.
- Filter linked pull request conversation comments through the same slash-command rule so PR reward evaluation does not re-add command comments.
- Keep normal discussion comments, issue specifications, pull request specs, and review comments available for evaluation.
- Add regression coverage for issue comments and linked pull request comments.

## Tests

- `node node_modules\jest\bin\jest.js tests\issue-activity-command-comments.test.ts --runInBand --no-coverage`
- `node node_modules\typescript\bin\tsc --noEmit`
- `node node_modules\eslint\bin\eslint.js src\issue-activity.ts src\helpers\comment-command.ts tests\issue-activity-command-comments.test.ts`
- `node node_modules\prettier\bin\prettier.cjs --check src\issue-activity.ts src\helpers\comment-command.ts tests\issue-activity-command-comments.test.ts`
- `git diff --check`

## Notes

- This supersedes the closed PR #636 by addressing the linked-PR comment path review feedback.