### PR TITLE
Fix review incentive eligibility for empty reviews

### DIFF
--- a/src/parser/review-incentivizer-module.ts
+++ b/src/parser/review-incentivizer-module.ts
@@ -3,7 +3,7 @@ import {
   ReviewIncentivizerConfiguration,
   reviewIncentivizerConfigurationType,
 } from "../configuration/review-incentivizer-config";
-import { GitHubPullRequestReviewState } from "../github-types";
+import { GitHubPullRequestReviewComment, GitHubPullRequestReviewState } from "../github-types";
 import { getExcludedFiles, shouldExcludeFile } from "../helpers/excluded-files";
 import { PullRequestData } from "../helpers/pull-request-data";
 import { IssueActivity } from "../issue-activity";
@@ -57,6 +57,7 @@ export class ReviewIncentivizerModule extends BaseModule {
             baseRef,
             headOwnerRepo ?? "",
             reviewsByUser,
+            linkedPullReviews.reviewComments,
             priority
           );
           reward.reviewRewards.push({ reviews: reviewDiffs, url: linkedPullReviews.self.html_url });
@@ -121,6 +122,7 @@ export class ReviewIncentivizerModule extends BaseModule {
     baseRef: string,
     headOwnerRepo: string,
     reviewsByUser: GitHubPullRequestReviewState[],
+    reviewComments: GitHubPullRequestReviewComment[] | null,
     priority: number
   ) {
     if (reviewsByUser.length == 0) {
@@ -139,11 +141,18 @@ export class ReviewIncentivizerModule extends BaseModule {
       throw this.context.logger.error("Could not fetch base commit for this pull request");
     }
     const excludedFilePatterns = await getExcludedFiles(this.context, baseOwner, baseRepo, baseRef);
-    for (const [i, currentReview] of reviewsByUser.entries()) {
+    let lastRewardedReviewCommitSha = firstCommitSha;
+    for (const currentReview of reviewsByUser) {
       if (!currentReview.commit_id) continue;
+      if (!this.isReviewEligibleForIncentives(currentReview, reviewComments)) {
+        this.context.logger.debug("Skipping review without body or inline comments", {
+          reviewId: currentReview.id,
+          state: currentReview.state,
+        });
+        continue;
+      }
 
-      const previousReview = reviewsByUser[i - 1];
-      const baseSha = previousReview?.commit_id ? previousReview.commit_id : firstCommitSha;
+      const baseSha = lastRewardedReviewCommitSha;
       const headSha = `${headOwnerRepo.replace("/", ":")}:${currentReview.commit_id}`;
 
       if (headSha && baseSha !== currentReview.commit_id) {
@@ -169,6 +178,7 @@ export class ReviewIncentivizerModule extends BaseModule {
             reward: ((reviewEffect.addition + reviewEffect.deletion) * priority) / this._baseRate,
             priority: priority,
           });
+          lastRewardedReviewCommitSha = currentReview.commit_id;
         } catch (e) {
           this.context.logger.error(`Failed to get diff between commits ${baseSha} and ${headSha}:`, { e });
         }
@@ -176,6 +186,17 @@ export class ReviewIncentivizerModule extends BaseModule {
     }
 
     return reviews;
+  }
+
+  private isReviewEligibleForIncentives(
+    review: GitHubPullRequestReviewState,
+    reviewComments: GitHubPullRequestReviewComment[] | null
+  ) {
+    const hasReviewBody = Boolean(review.body?.trim());
+    const hasInlineComment = reviewComments?.some(
+      (comment) => comment.pull_request_review_id === review.id && Boolean(comment.body?.trim())
+    );
+    return hasReviewBody || hasInlineComment;
   }
 
   get enabled(): boolean {

--- a/tests/file-exclusion.test.ts
+++ b/tests/file-exclusion.test.ts
@@ -7,6 +7,7 @@ import { server } from "./__mocks__/node";
 import cfg from "./__mocks__/results/valid-configuration.json";
 import { PullRequestData } from "../src/helpers/pull-request-data";
 import { ReviewIncentivizerModule } from "../src/parser/review-incentivizer-module";
+import { GitHubPullRequestReviewComment, GitHubPullRequestReviewState } from "../src/github-types";
 
 type MockGetContent = jest.Mock<
   (
@@ -34,6 +35,7 @@ beforeAll(() => server.listen());
 afterEach(() => {
   server.resetHandlers();
   mockGetContent.mockClear();
+  jest.restoreAllMocks();
 });
 afterAll(() => server.close());
 
@@ -72,6 +74,56 @@ describe("ReviewIncentivizerModule file exclusion", () => {
     );
     expect(result).toEqual({ addition: 100, deletion: 100 });
   });
+
+  it("should reward reviews with inline comments even when their body is empty", async () => {
+    mockPullRequestData();
+    mockGetContent.mockImplementation(mockNotFoundError);
+    const diffSpy = jest
+      .spyOn(reviewIncentivizer, "getReviewableDiff")
+      .mockResolvedValue({ addition: 10, deletion: 5 });
+
+    const result = await reviewIncentivizer.fetchReviewDiffRewards(
+      "owner",
+      "repo",
+      "main",
+      "fork/repo",
+      [mockReview({ id: 1, body: "", commitId: "commit-1" })],
+      [mockReviewComment(1)],
+      1
+    );
+
+    expect(result?.map((review) => review.reviewId)).toEqual([1]);
+    expect(diffSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should skip empty approvals and keep the previous rewarded commit as the next diff base", async () => {
+    mockPullRequestData();
+    mockGetContent.mockImplementation(mockNotFoundError);
+    const diffSpy = jest
+      .spyOn(reviewIncentivizer, "getReviewableDiff")
+      .mockResolvedValue({ addition: 10, deletion: 5 });
+
+    const result = await reviewIncentivizer.fetchReviewDiffRewards(
+      "owner",
+      "repo",
+      "main",
+      "fork/repo",
+      [
+        mockReview({ id: 1, body: "Reviewed first commit", commitId: "commit-1" }),
+        mockReview({ id: 2, state: "APPROVED", body: "", commitId: "commit-2" }),
+        mockReview({ id: 3, body: "Reviewed follow-up commit", commitId: "commit-3" }),
+      ],
+      [],
+      1
+    );
+
+    expect(result?.map((review) => review.reviewId)).toEqual([1, 3]);
+    expect(diffSpy).toHaveBeenCalledTimes(2);
+    expect(diffSpy.mock.calls[0][2]).toBe("base");
+    expect(diffSpy.mock.calls[0][3]).toBe("fork:repo:commit-1");
+    expect(diffSpy.mock.calls[1][2]).toBe("commit-1");
+    expect(diffSpy.mock.calls[1][3]).toBe("fork:repo:commit-3");
+  });
 });
 
 function mockFileResponse(content: string): Promise<OctokitResponse<unknown>> {
@@ -87,6 +139,45 @@ function mockNotFoundError(): Promise<never> {
   const error = new Error("Not Found") as Error & { status?: number };
   error.status = 404;
   return Promise.reject(error);
+}
+
+function mockPullRequestData() {
+  jest.spyOn(PullRequestData.prototype, "fetchData").mockResolvedValue(undefined);
+  jest.spyOn(PullRequestData.prototype, "pullCommits", "get").mockReturnValue([
+    {
+      sha: "first-commit",
+      parentCount: 1,
+      parents: [{ sha: "base" }],
+    },
+  ] as never);
+}
+
+function mockReview({
+  id,
+  state = "COMMENTED",
+  body = "",
+  commitId,
+}: {
+  id: number;
+  state?: string;
+  body?: string;
+  commitId: string;
+}) {
+  return {
+    id,
+    state,
+    body,
+    commit_id: commitId,
+    pull_request_url: "https://api.github.com/repos/owner/repo/pulls/1",
+    user: { login: "reviewer" },
+  } as GitHubPullRequestReviewState;
+}
+
+function mockReviewComment(reviewId: number, body = "Inline review comment") {
+  return {
+    pull_request_review_id: reviewId,
+    body,
+  } as GitHubPullRequestReviewComment;
 }
 
 describe("getExcludedFiles tests", () => {


### PR DESCRIPTION
Resolves #260

## Summary
- ignore reviews with no body and no inline review comments when calculating review incentives
- keep the diff baseline anchored to the last rewarded review so empty approvals cannot take or split credit
- add tests for inline-comment-only reviews and empty approvals

## Testing
- Not run locally: this workspace has no node/bun runtime or node_modules available.